### PR TITLE
Add test image and screenshots

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,8 @@
 *.tgz filter=lfs diff=lfs merge=lfs -text
 *.tar filter=lfs diff=lfs merge=lfs -text
 *.gz filter=lfs diff=lfs merge=lfs -text
+# Images
+*.png filter=lfs diff=lfs merge=lfs -text
+*.bmp filter=lfs diff=lfs merge=lfs -text
+*.jpg filter=lfs diff=lfs merge=lfs -text
+*.jpeg filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ https://ci.appveyor.com/project/michel-iwaniec/overlaypal
 
 A program to convert pixel images to NES constraints, by automatically assigning pixel image colors to background / sprite palettes.
 
+![Bernie](testimages/Bernie-converted.png) ![Bernie Converted BG](testimages/Bernie-converted_bg.png) ![Bernie Converted SPR](testimages/Bernie-converted_spr.png)
+
 ### Uhmm... why? Ain't a pixel drawing program enough to make NES pixel art?
 
 The NES was a quirky system in terms of graphics. Designed in an era where pixel memory was expensive, it provides only a single graphics mode.
@@ -54,6 +56,8 @@ Simply put a 192-byte .pal files (used by most NES emulators) in the "nespalette
 ### Converting an image
 
 Pressing "Convert" will convert the image using the CMPL optimisation solver. The right image will show a busy indicator, and eventually come back with a success or failure to convert. The "Generated Palettes" window will also show the background / sprite palettes of the output image.
+
+![OverlayPal screenshot](/screenshots/Bernie-screenshot.png)
 
 Successfully converted images can then be saved to a PNG file - optionally with different palette filters applied to separate background / overlay(s).
 

--- a/screenshots/Bernie-screenshot.png
+++ b/screenshots/Bernie-screenshot.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:11fcbe487b389f750697277e6a8629f22e7c9c7a18fa7275dde6fce0b8de5969
+size 112251

--- a/testimages/Bernie-converted.png
+++ b/testimages/Bernie-converted.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1183cc43e5d0a68ccb274a8dbd9231b635c736e570ad48a1d1b5ca84fd704d3c
+size 4041

--- a/testimages/Bernie-converted_bg.png
+++ b/testimages/Bernie-converted_bg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1673b91e88feb7c9a012ca5399db31298858ea101a65192e11062ec1f48d31a2
+size 3724

--- a/testimages/Bernie-converted_spr.png
+++ b/testimages/Bernie-converted_spr.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a97428fcda43bba655d8ed5d142dcd0b8fa9fbd40b2c9513391222a2ce5ba6a
+size 882

--- a/testimages/Bernie.png
+++ b/testimages/Bernie.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f65678507cd734f53fb209dc261cbc022d44ac14ad6ed819f65e8023849b7f83
+size 4590


### PR DESCRIPTION
Update documentation with test image and screenshot:
* Add png/jpg/bmp as LFS-tracked in .gitattributes
* Add testimage Bernie.png, conversion result and conversion result split into bg / spr
* Add screenshot of OverlayPal converting Bernie
* Add test images and screenshot to README