### PR TITLE
Fix bug with missing colors when moved into "free" sprite layer

### DIFF
--- a/src/cpp/Array2D.h
+++ b/src/cpp/Array2D.h
@@ -134,16 +134,15 @@ public:
         return mData[mWidth * y + x];
     }
 
-    bool empty(uint8_t emptyColor = 0) const
+    bool empty(T emptyValue = T()) const
     {
         if(mWidth > 0 && mHeight > 0)
         {
             for(size_t y = 0; y < mHeight; y++)
             {
-                for(size_t x = 0; x < mWidth; x++)
+                if(!emptyRow(y, emptyValue))
                 {
-                    if((*this)(x, y) != emptyColor)
-                        return false;
+                    return false;
                 }
             }
             return true;
@@ -154,13 +153,22 @@ public:
         }
     }
 
+    bool emptyRow(size_t y, T emptyValue = T()) const
+    {
+        for(size_t x = 0; x < mWidth; x++)
+        {
+            if((*this)(x, y) != emptyValue)
+                return false;
+        }
+        return true;
+    }
+
 protected:
 
     void initialiseFromOther(const Array2D& other)
     {
         assert(mWidth == other.width());
         assert(mHeight == other.height());
-        assert(other.mData != nullptr);
         for(int y = 0; y < mHeight; y++)
         {
             for(int x = 0; x < mWidth; x++)

--- a/src/cpp/OverlayOptimiser.h
+++ b/src/cpp/OverlayOptimiser.h
@@ -44,6 +44,7 @@ public:
         int y;
         int p;
         std::set<uint8_t> colors;
+        Image2D pixels;
     };
 
     OverlayOptimiser();
@@ -66,7 +67,9 @@ public:
 
     Image2D outputImageBackground() const;
 
-    Image2D outputImageOverlay() const;
+    Image2D outputImageOverlayGrid() const;
+
+    Image2D outputImageOverlayFree() const;
 
     Image2D outputImage() const;
 
@@ -85,7 +88,11 @@ public:
 
     const GridLayer& layerOverlay() const;
 
+    std::vector<OverlayOptimiser::Sprite> spritesOverlayGrid() const;
+    std::vector<OverlayOptimiser::Sprite> spritesOverlayFree() const;
     std::vector<OverlayOptimiser::Sprite> spritesOverlay() const;
+
+    static uint8_t indexInPalette(const std::set<uint8_t>& palette, uint8_t color);
 
 protected:
 
@@ -136,6 +143,8 @@ protected:
 
     void fillMissingPaletteGroups(std::vector<std::set<uint8_t>>& palettes);
 
+    OverlayOptimiser::Sprite extractSprite(Image2D& overlayImage, size_t x, size_t y, size_t spriteWidth, size_t spriteHeight, const std::set<uint8_t>& colors, bool removePixels) const;
+    OverlayOptimiser::Sprite extractSpriteWithBestPalette(Image2D& overlayImage, size_t x, size_t y, size_t spriteWidth, size_t spriteHeight, bool removePixels) const;
 private:
     std::string mExecutablePath;
     std::string mWorkPath;
@@ -144,6 +153,7 @@ private:
     Image2D mOutputImage;
     Image2D mOutputImageBackground;
     Image2D mOutputImageOverlay;
+    Image2D mOutputImageOverlayGrid;
     Image2D mOutputImageOverlayFree;
     std::vector<std::set<uint8_t>> mPalettes;
     std::unordered_map<uint8_t, uint8_t> mRemappingForward;
@@ -156,6 +166,8 @@ private:
     const int GridCellWidth = 16;
     const int GridCellHeight = 16;
     const size_t PaletteGroupSize = 4;
+    const size_t NumBackgroundPalettes = 4;
+    const size_t NumSpritePalettes = 4;
     const char* firstPassProgramInputFilename = "FirstPass.cmpl";
     const char* firstPassProgramOutputFilename = "FirstPass_withTimeOut.cmpl";
     const char* firstPassSolutionFilename = "firstpass_output.csv";

--- a/src/cpp/OverlayPalGuiBackend.cpp
+++ b/src/cpp/OverlayPalGuiBackend.cpp
@@ -538,11 +538,6 @@ void OverlayPalGuiBackend::startImageConversion()
             Image2D remappedImage = mOverlayOptimiser.outputImage();
             mOutputImage = image2DToQImage(remappedImage, colorTable);
             //
-            Image2D remappedImageOverlay = mOverlayOptimiser.outputImageOverlay();
-            mOutputImageOverlay = image2DToQImage(remappedImageOverlay, colorTable);
-            //
-            Image2D remappedImageBackground = mOverlayOptimiser.outputImageBackground();
-            QImage outputImageBackground = image2DToQImage(remappedImage, colorTable);
             const std::vector<std::set<uint8_t>>& palettes = mOverlayOptimiser.palettes();
             mPaletteModel.setPalette(palettes, mBackgroundColor);
             mConversionError = "";
@@ -937,20 +932,6 @@ QVariantList OverlayPalGuiBackend::debugDestinationColorsBackground() const
 
 //---------------------------------------------------------------------------------------------------------------------
 
-uint8_t OverlayPalGuiBackend::indexInPalette(const std::set<uint8_t>& palette, uint8_t color)
-{
-    uint8_t i = 1;
-    for(uint8_t c : palette)
-    {
-        if(c == color)
-            return i;
-        i++;
-    }
-    return 0;
-}
-
-//---------------------------------------------------------------------------------------------------------------------
-
 QString OverlayPalGuiBackend::urlToLocal(const QString &url)
 {
     return QUrl(url).toLocalFile();
@@ -977,8 +958,8 @@ QVariantList OverlayPalGuiBackend::debugSpritesOverlay() const
         for(uint8_t c : s.colors)
         {
             srcColors.push_back(c);
-            uint8_t dstColor = indexInPalette(palettes[s.p], c);
-            dstColors.push_back(dstColor | 0x10);
+            uint8_t dstColor = mOverlayOptimiser.indexInPalette(palettes[s.p], c);
+            dstColors.push_back((s.p << 2) | dstColor);
             i++;
         }
         m["srcColors"] = colorsToQString(srcColors, 1);


### PR DESCRIPTION
* Add Image2D member "pixels" to each sprite, to (optionally) track pixels of sprite
* Add new method spriteOverlayFree to build off-grid sprites from "free" layer
* Rename old spritesOverlay to spritesOverlayGrid, and add new spritesOverlay function to add both
* Add function outputImageOverlayFree to draw output of spritesOverlayFree to an image
* Modify OverlayOptimiser::outputImage to use outputImageOverlayFree in composition
* Remove some asserts and dead code
* Move OverlayPalGuiBackend::indexInPalette to OverlayOptimiser to allow re-use

Other:
* Fix incorrect palette indices in SPR debug visualisation, by fixing bug in OverlayPalGuiBackend::debugSpritesOverlay()