### PR TITLE
Fail more gracefully on conversion errors

### DIFF
--- a/src/cpp/Array2D.h
+++ b/src/cpp/Array2D.h
@@ -38,7 +38,7 @@ public:
     {
     }
 
-    Array2D(int width, int height):
+    Array2D(int width, int height, T initValue = T()):
         mWidth(width),
         mHeight(height),
         mData(nullptr)
@@ -50,7 +50,7 @@ public:
             {
                 for(size_t x = 0; x < mWidth; x++)
                 {
-                    (*this)(x, y) = T();
+                    (*this)(x, y) = initValue;
                 }
             }
         }

--- a/src/cpp/OverlayOptimiser.h
+++ b/src/cpp/OverlayOptimiser.h
@@ -55,13 +55,13 @@ public:
     std::string exePathFilename(const std::string& exeFilename) const;
     std::string workPathFilename(const std::string& workFilename) const;
 
-    void convert(const Image2D& image,
-                 uint8_t backgroundColor,
-                 int gridCellColorLimit,
-                 int maxBackgroundPalettes,
-                 int maxSpritePalettes,
-                 int maxSpritesPerScanline,
-                 int timeOut);
+    std::string convert(const Image2D& image,
+                        uint8_t backgroundColor,
+                        int gridCellColorLimit,
+                        int maxBackgroundPalettes,
+                        int maxSpritePalettes,
+                        int maxSpritesPerScanline,
+                        int timeOut);
 
     bool conversionSuccessful() const;
 
@@ -91,6 +91,8 @@ public:
     std::vector<OverlayOptimiser::Sprite> spritesOverlayGrid() const;
     std::vector<OverlayOptimiser::Sprite> spritesOverlayFree() const;
     std::vector<OverlayOptimiser::Sprite> spritesOverlay() const;
+
+    int getMaxSpritesPerScanline(const std::vector<OverlayOptimiser::Sprite>& sprites) const;
 
     static uint8_t indexInPalette(const std::set<uint8_t>& palette, uint8_t color);
 


### PR DESCRIPTION
* Change OverlayPalGuiBackend::startImageConversion to create dummy black image when catching exception
* Update Array2D to allow specifying init value
* Change OverlayOptimiser::convert to attempt conversion with 2x maxSpriteScanlines, and report success / failure based on actual max sprites count