### PR TITLE
Bugfix for directories with spaces not working

### DIFF
--- a/src/cpp/OverlayOptimiser.cpp
+++ b/src/cpp/OverlayOptimiser.cpp
@@ -31,6 +31,13 @@
 
 //---------------------------------------------------------------------------------------------------------------------
 
+std::string quoteString(const std::string& s)
+{
+    return std::string("\"") + s + std::string("\"");
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+
 OverlayOptimiser::OverlayOptimiser():
     mBackgroundColor(0)
 {
@@ -134,8 +141,8 @@ void OverlayOptimiser::runCmplProgram(const std::string& inputFilename,
     // Execute process
     std::string cmplExecutable("Cmpl/bin/cmpl");
     std::string params;
-    params += " -i " + outputFilename;
-    params += " -solutionCsv " + solutionCsvFilename;
+    params += " -i " + quoteString(outputFilename);
+    params += " -solutionCsv " + quoteString(solutionCsvFilename);
     int exitCode = executeProcess(exePathFilename(cmplExecutable), params, timeOut);
     if(exitCode != 0)
     {

--- a/src/cpp/OverlayOptimiser.cpp
+++ b/src/cpp/OverlayOptimiser.cpp
@@ -31,13 +31,6 @@
 
 //---------------------------------------------------------------------------------------------------------------------
 
-std::string quoteString(const std::string& s)
-{
-    return std::string("\"") + s + std::string("\"");
-}
-
-//---------------------------------------------------------------------------------------------------------------------
-
 OverlayOptimiser::OverlayOptimiser():
     mBackgroundColor(0)
 {
@@ -141,8 +134,8 @@ void OverlayOptimiser::runCmplProgram(const std::string& inputFilename,
     // Execute process
     std::string cmplExecutable("Cmpl/bin/cmpl");
     std::string params;
-    params += " -i " + quoteString(outputFilename);
-    params += " -solutionCsv " + quoteString(solutionCsvFilename);
+    params += " -i " + quoteStringOnWindows(outputFilename);
+    params += " -solutionCsv " + quoteStringOnWindows(solutionCsvFilename);
     int exitCode = executeProcess(exePathFilename(cmplExecutable), params, timeOut);
     if(exitCode != 0)
     {

--- a/src/cpp/SubProcess.cpp
+++ b/src/cpp/SubProcess.cpp
@@ -32,6 +32,12 @@
 #include "SubProcess.h"
 
 #ifdef _WIN32
+
+std::string quoteStringOnWindows(const std::string& s)
+{
+    return std::string("\"") + s + std::string("\"");
+}
+
 int executeProcess(std::string exeFilename,
                    std::string params,
                    int timeOut)
@@ -80,6 +86,11 @@ int executeProcess(std::string exeFilename,
     }
 }
 #else
+
+std::string quoteStringOnWindows(const std::string& s)
+{
+    return s;
+}
 
 std::vector<char*> splitParams(std::string& params)
 {

--- a/src/cpp/SubProcess.h
+++ b/src/cpp/SubProcess.h
@@ -24,4 +24,6 @@
 
 int executeProcess(std::string exeFilename, std::string params, int timeOut);
 
+std::string quoteStringOnWindows(const std::string& s);
+
 #endif // SUB_PROCESS_H


### PR DESCRIPTION
* Add function quoteStringOnWindows to put a string in double-quotes on Windows only
* Make OverlayOptimiser::runCmplProgram quote filename parameters when invoking subprocess