### PR TITLE
Post-optimize sprites by merging horizontally adjacent where possible:

### DIFF
--- a/src/cpp/OverlayOptimiser.h
+++ b/src/cpp/OverlayOptimiser.h
@@ -96,6 +96,13 @@ public:
 
     static uint8_t indexInPalette(const std::set<uint8_t>& palette, uint8_t color);
 
+    int getNumBlankPixelsLeft(Sprite sprite) const;
+    int getNumBlankPixelsRight(Sprite sprite) const;
+
+    std::vector<std::vector<Sprite>> getAdjacentSlices(std::vector<Sprite> sprites) const;
+
+    std::vector<Sprite> optimizeHorizontallyAdjacentSprites(const std::vector<Sprite>& sprites) const;
+
 protected:
 
     void writeCmplDataFile(const GridLayer& layer, int gridCellColorLimit, int maxBackgroundPalettes, int maxSpritePalettes, int maxRowSize, const std::string& filename);
@@ -165,6 +172,7 @@ private:
     Array2D<uint8_t> mPaletteIndicesBackground;
     Array2D<uint8_t> mPaletteIndicesOverlay;
     const int SpriteWidth = 8;
+    const int SpriteHeight = 16;
     const int GridCellWidth = 16;
     const int GridCellHeight = 16;
     const size_t PaletteGroupSize = 4;


### PR DESCRIPTION
* Modify spritesOverlayGrid to extract sprite pixels in similar fashion to spritesOverlayFree
* Add new method getAdjacentSlices to break up sprites into horizontally adjacent "slices" sharing same palette
* Add new method optimizeHorizontallyAdjacentSprites to shift slices and discard sprite when enough blank pixel columns are present to the left / right
* Add call to optimizeHorizontallyAdjacentSprites in spritesOverlay method