### PR TITLE
Add support for 8x8 sprites mode:

### DIFF
--- a/src/cpp/OverlayOptimiser.h
+++ b/src/cpp/OverlayOptimiser.h
@@ -57,6 +57,7 @@ public:
 
     std::string convert(const Image2D& image,
                         uint8_t backgroundColor,
+                        int _spriteHeight,
                         int gridCellColorLimit,
                         int maxBackgroundPalettes,
                         int maxSpritePalettes,
@@ -102,6 +103,9 @@ public:
     std::vector<std::vector<Sprite>> getAdjacentSlices(std::vector<Sprite> sprites) const;
 
     std::vector<Sprite> optimizeHorizontallyAdjacentSprites(const std::vector<Sprite>& sprites) const;
+
+    int spriteWidth() const;
+    int spriteHeight() const;
 
 protected:
 
@@ -154,11 +158,27 @@ protected:
 
     OverlayOptimiser::Sprite extractSprite(Image2D& overlayImage, size_t x, size_t y, size_t spriteWidth, size_t spriteHeight, const std::set<uint8_t>& colors, bool removePixels) const;
     OverlayOptimiser::Sprite extractSpriteWithBestPalette(Image2D& overlayImage, size_t x, size_t y, size_t spriteWidth, size_t spriteHeight, bool removePixels) const;
+
+    template<typename T>
+    static Array2D<T> doubleArrayHeight(const Array2D<T>& array)
+    {
+        Array2D<T> newArray(array.width(), 2 * array.height());
+        for(size_t y = 0; y < array.height(); y++)
+        {
+            for(size_t x = 0; x < array.width(); x++)
+            {
+                newArray(x, 2 * y + 0) = array(x, y);
+                newArray(x, 2 * y + 1) = array(x, y);
+            }
+        }
+        return newArray;
+    }
 private:
     std::string mExecutablePath;
     std::string mWorkPath;
     bool mConversionSuccessful;
     uint8_t mBackgroundColor;
+    int mSpriteHeight;
     Image2D mOutputImage;
     Image2D mOutputImageBackground;
     Image2D mOutputImageOverlay;
@@ -172,7 +192,6 @@ private:
     Array2D<uint8_t> mPaletteIndicesBackground;
     Array2D<uint8_t> mPaletteIndicesOverlay;
     const int SpriteWidth = 8;
-    const int SpriteHeight = 16;
     const int GridCellWidth = 16;
     const int GridCellHeight = 16;
     const size_t PaletteGroupSize = 4;

--- a/src/cpp/OverlayPalGuiBackend.cpp
+++ b/src/cpp/OverlayPalGuiBackend.cpp
@@ -432,6 +432,20 @@ void OverlayPalGuiBackend::setShiftY(const int &shiftY)
 
 //---------------------------------------------------------------------------------------------------------------------
 
+int OverlayPalGuiBackend::spriteHeight() const
+{
+    return mSpriteHeight;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+
+void OverlayPalGuiBackend::setSpriteHeight(int spriteHeight)
+{
+    mSpriteHeight = spriteHeight;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+
 int OverlayPalGuiBackend::maxBackgroundPalettes() const
 {
     return mMaxBackgroundPalettes;
@@ -544,6 +558,7 @@ void OverlayPalGuiBackend::startImageConversion()
         try {
             std::string conversionError = mOverlayOptimiser.convert(mImagePendingConversion,
                                                                     mBackgroundColor,
+                                                                    mSpriteHeight,
                                                                     GridCellColorLimit,
                                                                     mMaxBackgroundPalettes,
                                                                     mMaxSpritePalettes,
@@ -959,6 +974,9 @@ QVariantList OverlayPalGuiBackend::debugSpritesOverlay() const
         // Make palette start at 0 to match "SPR0" designation
         m["p"] = s.p - 4;
         m["numColors"] = int(s.colors.size());
+        // Get current sprite width / height from optimiser
+        m["w"] = mOverlayOptimiser.spriteWidth();
+        m["h"] = mOverlayOptimiser.spriteHeight();
         std::vector<uint8_t> srcColors;
         std::vector<uint8_t> dstColors;
         uint8_t i = 1;
@@ -969,8 +987,9 @@ QVariantList OverlayPalGuiBackend::debugSpritesOverlay() const
             dstColors.push_back((s.p << 2) | dstColor);
             i++;
         }
-        m["srcColors"] = colorsToQString(srcColors, 1);
-        m["dstColors"] = colorsToQString(dstColors, 1);
+        int valuesPerLine = (mOverlayOptimiser.spriteHeight() == 8) ? 2 : 1;
+        m["srcColors"] = colorsToQString(srcColors, valuesPerLine);
+        m["dstColors"] = colorsToQString(dstColors, valuesPerLine);
         spritesQML.push_back(m);
     }
     return spritesQML;

--- a/src/cpp/OverlayPalGuiBackend.h
+++ b/src/cpp/OverlayPalGuiBackend.h
@@ -45,6 +45,7 @@ class OverlayPalGuiBackend : public QObject
     Q_PROPERTY(QString inputImageFilename READ inputImageFilename WRITE setInputImageFilename)
     Q_PROPERTY(int shiftX READ shiftX WRITE setShiftX NOTIFY shiftXChanged)
     Q_PROPERTY(int shiftY READ shiftY WRITE setShiftY NOTIFY shiftYChanged)
+    Q_PROPERTY(int spriteHeight READ spriteHeight WRITE setSpriteHeight)
     Q_PROPERTY(int maxBackgroundPalettes READ maxBackgroundPalettes WRITE setMaxBackgroundPalettes)
     Q_PROPERTY(int maxSpritePalettes READ maxSpritePalettes WRITE setMaxSpritePalettes)
     Q_PROPERTY(int maxSpritesPerScanline READ maxSpritesPerScanline WRITE setMaxSpritesPerScanline)
@@ -74,6 +75,8 @@ public:
     bool potentialHardwarePaletteIndexedImage() const;
     bool mapInputColors() const;
     void setMapInputColors(bool mapInputColors);
+    int spriteHeight() const;
+    void setSpriteHeight(int spriteHeight);
     int maxBackgroundPalettes() const;
     void setMaxBackgroundPalettes(int maxBackgroundPalettes);
     int maxSpritePalettes() const;
@@ -165,6 +168,7 @@ private:
     bool mTrackInputImage;
     int mShiftX;
     int mShiftY;
+    int mSpriteHeight;
     int mMaxBackgroundPalettes;
     int mMaxSpritePalettes;
     int mMaxSpritesPerScanline;

--- a/src/qml/GridLayerCanvas.qml
+++ b/src/qml/GridLayerCanvas.qml
@@ -271,32 +271,47 @@ Item {
 
     function drawDebugTextSpr(ctx, sprites, keyword, useRows)
     {
-        var qScale = useRows ? 0.5 : 1.0;
-        var gridCellWidth = 8;
-        var gridCellHeight = 16;
-        ctx.fillStyle = debugColor;
-        ctx.font = (zoom * gridCellWidth * qScale) + 'px sans-serif';
-        ctx.textAlign = 'center';
-        ctx.textBaseline = 'bottom';
-        ctx.lineWidth = 1;
-        ctx.strokeStyle = debugColor;
+        var spriteWidth = 8;
         for(var i = 0; i < sprites.length; i++)
         {
             var s = sprites[i];
-            var x = s.x + 0.5 * gridCellWidth;
-            var y = s.y + qScale * gridCellHeight;
             ctx.rect(s.x * zoom + 0.5,
                      s.y * zoom + 0.5,
-                     gridCellWidth * zoom,
-                     gridCellHeight * zoom);
+                     s.w * zoom,
+                     s.h * zoom);
             ctx.stroke();
-            if(useRows)
+            ctx.fillStyle = debugColor;
+            var qScale;
+            if(useRows && (s.h == 16))
             {
-                drawDebugTextImplRows(ctx, x, y, gridCellHeight, s[keyword]);
+                qScale = useRows ? 0.5 : 1.0;
+            }
+            else if(s.h == 8)
+            {
+                qScale = useRows ? 0.4 : 1.0;
             }
             else
             {
-                drawDebugTextImpl(ctx, x, y, gridCellHeight, s[keyword], false, useRows);
+                qScale = useRows ? 0.5 : 1.0;
+            }
+            ctx.font = (zoom * spriteWidth * qScale) + 'px sans-serif';
+            ctx.textAlign = 'center';
+            ctx.textBaseline = 'bottom';
+            ctx.lineWidth = 1;
+            ctx.strokeStyle = debugColor;
+            var x = s.x + 0.5 * s.w;
+            var y = s.y + qScale * s.h;
+            if(useRows && (s.h == 8))
+            {
+                drawDebugTextImpl(ctx, x, y + 0.1 * s.h, s.h, s[keyword], true);
+            }
+            else if(useRows)
+            {
+                drawDebugTextImplRows(ctx, x, y, s.h, s[keyword]);
+            }
+            else
+            {
+                drawDebugTextImpl(ctx, x, y, s.h, s[keyword], false, useRows);
             }
         }
     }

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -119,6 +119,7 @@ Window {
             inputImageGroupBox.enabled = true;
             shiftGroupBox.enabled = true;
             optimisationSettingsGroupBox.enabled = true;
+            spriteModeComboBox.enabled = true;
             // Set groupbox title to either success message or error string
             if(optimiser.conversionSuccessful)
             {
@@ -153,6 +154,7 @@ Window {
             inputImageGroupBox.enabled = false;
             shiftGroupBox.enabled = false;
             optimisationSettingsGroupBox.enabled = false;
+            spriteModeComboBox.enabled = false;
             conversionBusy.running = true;
             dstImageGroupBox.title = "Conversion running...";
             optimiser.startImageConversion();
@@ -553,6 +555,40 @@ Window {
             }
 
             GroupBox {
+                id: sizesModeGroupBox
+                width: 160
+                height: 200
+                title: qsTr("Size mode")
+
+                GridLayout {
+                    x: 0
+                    y: 7
+                    rows: 1
+                    columns: 2
+
+                    Label {
+                        id: spriteModeLabel
+                        text: qsTr("SPR")
+                        font.pointSize: 10
+                    }
+
+                    ComboBox {
+                        id: spriteModeComboBox
+                        model: ["8x16", "8x8"]
+                        Layout.fillHeight: false
+                        Layout.preferredHeight: 40
+                        Layout.preferredWidth: 80
+                        onCurrentIndexChanged: {
+                            console.debug(model[currentIndex])
+                            optimiser.spriteHeight = (model[currentIndex] == "8x8" ? 8 : 16);
+                        }
+                        Component.onCompleted: {
+                        }
+                    }
+                }
+            }
+
+            GroupBox {
                 id: showHideColorsGroupBox
                 width: 225
                 height: 200
@@ -839,6 +875,7 @@ Window {
                                 // Disable manual conversion button
                                 convertImageButton.enabled = false
                                 // Connect signals to start automatically
+                                spriteModeComboBox.currentValueChanged.connect(optimiser.startImageConversionWrapper);
                                 xShiftSpinBox.valueModified.connect(optimiser.startImageConversionWrapper);
                                 yShiftSpinBox.valueModified.connect(optimiser.startImageConversionWrapper);
                                 maxBackgroundPalettesSpinBox.valueModified.connect(optimiser.startImageConversionWrapper);
@@ -853,6 +890,7 @@ Window {
                                 // Re-enable manual conversion button
                                 convertImageButton.enabled = true
                                 // Disconnect signals to stop starting automatically
+                                spriteModeComboBox.currentValueChanged.disconnect(optimiser.startImageConversionWrapper);
                                 xShiftSpinBox.valueModified.disconnect(optimiser.startImageConversionWrapper);
                                 yShiftSpinBox.valueModified.disconnect(optimiser.startImageConversionWrapper);
                                 maxBackgroundPalettesSpinBox.valueModified.disconnect(optimiser.startImageConversionWrapper);


### PR DESCRIPTION
* Add member mSpriteHeight to OverlayOptimiser class, with getters and setters
* Add helper function doubleArrayHeight for splitting palette indices after first CMPL pass is done
* Make code in OverlayOptimiser adjust conversion based on mSpriteHeight
* Add property spriteHeight to OverlayPalGuiBackend class
* Pass spriteHeight property from OverlayPalGuiBackend when starting conversion
* Update conversion to use a height of either 8 or 16 pixels for grid layers / CMPL solving
* Update OverlayPalGuiBackend::debugSpritesOverlay() to set w / h keys in output based on OverlayOptimiser's mSpriteHeight
* OverlayPalGuiBackend::debugSpritesOverlay() to make sure 8x8 sprites use quadrant-style line-splitting
* Update GridLayerCanvas.qml to draw sprite rectangles based on w / h instead of grid cell
* Update GridLayerCanvas to adjust color placement / size within rectangles for 8x8 sprites
* Add UI in main.qml for selecting either 8x16 or 8x8 mode through a ComboBox, setting spriteHeight property in OverlayPalGuiBackend