### PR TITLE
Improve horizontal sprites optimization to merge parts of an adjacent slice:

### DIFF
--- a/src/cpp/OverlayOptimiser.h
+++ b/src/cpp/OverlayOptimiser.h
@@ -45,6 +45,8 @@ public:
         int p;
         std::set<uint8_t> colors;
         Image2D pixels;
+        int numBlankPixelsLeft;
+        int numBlankPixelsRight;
     };
 
     OverlayOptimiser();


### PR DESCRIPTION
* Add members variables for number of blank pixel columns at left / right side
* Initialize new member variables and iterate over all possible ranges of slice in OverlayOptimiser::optimizeHorizontallyAdjacentSprites