### PR TITLE
Add option for ensuring unique colors in color mapping:

### DIFF
--- a/src/cpp/OverlayPalGuiBackend.h
+++ b/src/cpp/OverlayPalGuiBackend.h
@@ -41,6 +41,7 @@ class OverlayPalGuiBackend : public QObject
     Q_PROPERTY(bool trackInputImage READ trackInputImage WRITE setTrackInputImage)
     Q_PROPERTY(bool potentialHardwarePaletteIndexedImage READ potentialHardwarePaletteIndexedImage)
     Q_PROPERTY(bool mapInputColors READ mapInputColors WRITE setMapInputColors NOTIFY mapInputColorsChanged)
+    Q_PROPERTY(bool uniqueColors READ uniqueColors WRITE setUniqueColors)
     Q_PROPERTY(int backgroundColor READ backgroundColor WRITE setBackgroundColor NOTIFY backgroundColorChanged)
     Q_PROPERTY(QString inputImageFilename READ inputImageFilename WRITE setInputImageFilename)
     Q_PROPERTY(int shiftX READ shiftX WRITE setShiftX NOTIFY shiftXChanged)
@@ -75,6 +76,8 @@ public:
     bool potentialHardwarePaletteIndexedImage() const;
     bool mapInputColors() const;
     void setMapInputColors(bool mapInputColors);
+    bool uniqueColors() const;
+    void setUniqueColors(bool uniqueColors);
     int spriteHeight() const;
     void setSpriteHeight(int spriteHeight);
     int maxBackgroundPalettes() const;
@@ -153,7 +156,7 @@ protected:
     void setHardwarePaletteName(const QString& hardwarePaletteName);
     void loadHardwarePalette(const QFileInfo& fileInfo);
     void loadHardwarePalettes(const QString& palettesPath);
-    uint8_t findClosestColorIndex(const QVector<QRgb>& colorTable, QRgb rgb);
+    uint8_t findClosestColorIndex(const QVector<QRgb>& colorTable, QRgb rgb, std::vector<bool>& availableColors);
     QImage remapColorsToNES(const QImage& inputImage, uint8_t& backgroundColor);
 
     static QImage cropOrExtendImage(const QImage& image, uint8_t backgroundColor);
@@ -164,6 +167,7 @@ protected:
     static QString urlToLocal(const QString& url);
 
 private:
+    bool mUniqueColors;
     int mTimeOut;
     bool mTrackInputImage;
     int mShiftX;

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -311,14 +311,15 @@ Window {
 
                 GridLayout {
                     x: 0
-                    y: 7
-                    rows: 3
+                    y: 2
+                    rows: 4
                     columns: 2
+                    rowSpacing: 0
 
                     Button {
                         id: loadImageButton
                         text: qsTr("Load PNG image...")
-                        Layout.preferredHeight: 40
+                        Layout.preferredHeight: 36
                         Layout.preferredWidth: 141
                         property int inputImageIndex: 0
                         Component.onCompleted: {
@@ -329,7 +330,7 @@ Window {
                     CheckBox {
                         id: trackInputImageCheckBox
                         text: qsTr("Track file")
-                        Layout.preferredHeight: 40
+                        Layout.preferredHeight: 36
                         Layout.preferredWidth: 113
                         leftPadding: 0
                         onCheckStateChanged: optimiser.trackInputImage = trackInputImageCheckBox.checked;
@@ -342,7 +343,10 @@ Window {
                         font.pointSize: 10
                         enabled: true
                         checked: true
-                        onCheckStateChanged: optimiser.mapInputColors = checked
+                        onCheckStateChanged: {
+                            optimiser.mapInputColors = checked
+                            uniqueColorsCheckBox.enabled = checked
+                        }
                     }
 
                     ComboBox {
@@ -353,7 +357,7 @@ Window {
                         Layout.fillWidth: true
                         rightPadding: 0
                         Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
-                        Layout.preferredHeight: 40
+                        Layout.preferredHeight: 36
                         Layout.preferredWidth: 118
                         onCurrentIndexChanged: {
                             var model = paletteFlavorComboBox.model
@@ -363,6 +367,22 @@ Window {
                         Component.onCompleted: {
                             paletteFlavorComboBox.model = optimiser.hardwarePaletteNamesModel();
                         }
+                    }
+
+                    CheckBox {
+                        id: uniqueColorsCheckBox
+                        text: qsTr("Unique colors")
+                        leftPadding: 0
+                        font.pointSize: 10
+                        enabled: true
+                        checked: false
+                        onCheckStateChanged: optimiser.uniqueColors = checked
+                    }
+
+                    Label {
+                        id: uniqueColorsEmptyLabel
+                        text: qsTr("")
+                        font.pointSize: 10
                     }
 
                     Label {
@@ -380,7 +400,7 @@ Window {
                             optimiser.backgroundColor = bgColor;
                         }
                         Layout.fillHeight: false
-                        Layout.preferredHeight: 40
+                        Layout.preferredHeight: 36
                         Layout.preferredWidth: 118
 
                         contentItem: Text {


### PR DESCRIPTION
* Add property uniqueColors to OverlayPalGuiBackend
* Change remapColorsToNES to iterate over (unique) RGB values present in QImage rather than entries in its color table
* Update remapColorsToNES / findClosestColorIndex to only use same color once when feature is on
* Add "Ensure unique colors" Checkbox in QML to input image groupbox to turn feature on/off
* Adjust neighbour elements in image groupbox to make new checkbox fit