### PR TITLE
Add support for 8x8 background attributes:

### DIFF
--- a/src/cpp/OverlayOptimiser.cpp
+++ b/src/cpp/OverlayOptimiser.cpp
@@ -484,6 +484,8 @@ bool OverlayOptimiser::convertSecondPass(int gridCellColorLimit,
 
 std::string OverlayOptimiser::convert(const Image2D& image,
                                       uint8_t backgroundColor,
+                                      int gridCellWidth,
+                                      int gridCellHeight,
                                       int _spriteHeight,
                                       int gridCellColorLimit,
                                       int maxBackgroundPalettes,
@@ -507,17 +509,17 @@ std::string OverlayOptimiser::convert(const Image2D& image,
     mBackgroundColor = backgroundColor;
     mSpriteHeight = _spriteHeight;
     // Halve GridCellWidth for sprite layer after first pass
-    int OverlayGridCellWidth = GridCellWidth / 2;
-    int OverlayWidth = image.width() / OverlayGridCellWidth; //layer.width() * 2;
+    int OverlayGridCellWidth = spriteWidth();
+    int OverlayWidth = image.width() / OverlayGridCellWidth;
     Image2D imageBackground(image.width(), image.height());
     Image2D imageOverlay(image.width(), image.height());
     Image2D imageOverlayGrid(image.width(), image.height());
     Image2D imageOverlayFree(image.width(), image.height());
-    GridLayer layer(backgroundColor, GridCellWidth, GridCellHeight, image);
+    GridLayer layer(backgroundColor, gridCellWidth, gridCellHeight, image);
     GridLayer layerBackground(backgroundColor, layer.cellWidth(), layer.cellHeight(), layer.width(), layer.height());
     GridLayer layerOverlay(backgroundColor, layer.cellWidth(), layer.cellHeight(), layer.width(), layer.height());
     Array2D<uint8_t> paletteIndicesBackground(layer.width(), layer.height());
-    Array2D<uint8_t> paletteIndicesOverlay(OverlayWidth, layerOverlay.height());
+    Array2D<uint8_t> paletteIndicesOverlay(OverlayWidth, imageOverlayGrid.height() / _spriteHeight );
     // Initialise output data to blank values
     const Image2D blankImage = Image2D(image.width(), image.height(), mBackgroundColor);
     const GridLayer blankLayer = GridLayer(mBackgroundColor, OverlayGridCellWidth, layer.cellHeight(), OverlayWidth, layer.height());
@@ -531,7 +533,7 @@ std::string OverlayOptimiser::convert(const Image2D& image,
     mPaletteIndicesBackground = paletteIndicesBackground;
     mPaletteIndicesOverlay = paletteIndicesOverlay;
     // * 2 to always get a visible solution, even if beyond constraints
-    int maxRowSize = maxSpritesPerScanline;
+    int maxRowSize = ((2 * spriteWidth()) / gridCellWidth) * maxSpritesPerScanline;
     // Execute first pass
     std::vector<std::set<uint8_t>> palettes;
     bool successPassOne = convertFirstPass(image,
@@ -573,10 +575,6 @@ std::string OverlayOptimiser::convert(const Image2D& image,
     layerOverlay = GridLayer(backgroundColor, OverlayGridCellWidth, spriteHeight(), imageOverlay);
     GridLayer layerOverlayGrid(backgroundColor, OverlayGridCellWidth, spriteHeight(), OverlayWidth, layerOverlay.height());
     GridLayer layerOverlayFree(backgroundColor, OverlayGridCellWidth, spriteHeight(), OverlayWidth, layerOverlay.height());
-    if(spriteHeight() == 8)
-    {
-        paletteIndicesOverlay = doubleArrayHeight(paletteIndicesOverlay);
-    }
     // Second pass
     bool successPassTwo = convertSecondPass(gridCellColorLimit,
                                             maxSpritePalettes,

--- a/src/cpp/OverlayOptimiser.h
+++ b/src/cpp/OverlayOptimiser.h
@@ -59,6 +59,8 @@ public:
 
     std::string convert(const Image2D& image,
                         uint8_t backgroundColor,
+                        int gridCellWidth,
+                        int gridCellHeight,
                         int _spriteHeight,
                         int gridCellColorLimit,
                         int maxBackgroundPalettes,
@@ -161,20 +163,6 @@ protected:
     OverlayOptimiser::Sprite extractSprite(Image2D& overlayImage, size_t x, size_t y, size_t spriteWidth, size_t spriteHeight, const std::set<uint8_t>& colors, bool removePixels) const;
     OverlayOptimiser::Sprite extractSpriteWithBestPalette(Image2D& overlayImage, size_t x, size_t y, size_t spriteWidth, size_t spriteHeight, bool removePixels) const;
 
-    template<typename T>
-    static Array2D<T> doubleArrayHeight(const Array2D<T>& array)
-    {
-        Array2D<T> newArray(array.width(), 2 * array.height());
-        for(size_t y = 0; y < array.height(); y++)
-        {
-            for(size_t x = 0; x < array.width(); x++)
-            {
-                newArray(x, 2 * y + 0) = array(x, y);
-                newArray(x, 2 * y + 1) = array(x, y);
-            }
-        }
-        return newArray;
-    }
 private:
     std::string mExecutablePath;
     std::string mWorkPath;
@@ -194,8 +182,6 @@ private:
     Array2D<uint8_t> mPaletteIndicesBackground;
     Array2D<uint8_t> mPaletteIndicesOverlay;
     const int SpriteWidth = 8;
-    const int GridCellWidth = 16;
-    const int GridCellHeight = 16;
     const size_t PaletteGroupSize = 4;
     const size_t NumBackgroundPalettes = 4;
     const size_t NumSpritePalettes = 4;

--- a/src/cpp/OverlayPalGuiBackend.cpp
+++ b/src/cpp/OverlayPalGuiBackend.cpp
@@ -87,7 +87,9 @@ OverlayPalGuiBackend::OverlayPalGuiBackend(QObject *parent):
     mOutputImage(ScreenWidth, ScreenHeight, QImage::Format_Indexed8),
     mBackgroundColor(0),
     mInputImage(ScreenWidth, ScreenHeight, QImage::Format_Indexed8),
-    mInputImageIndexed(ScreenWidth, ScreenHeight, QImage::Format_Indexed8)
+    mInputImageIndexed(ScreenWidth, ScreenHeight, QImage::Format_Indexed8),
+    mGridCellWidth(16),
+    mGridCellHeight(16)
 {
     mInputImage.fill(0);
     mInputImageIndexed.fill(0);
@@ -451,6 +453,21 @@ void OverlayPalGuiBackend::setShiftY(const int &shiftY)
 
 //---------------------------------------------------------------------------------------------------------------------
 
+QSize OverlayPalGuiBackend::cellSize() const
+{
+    return QSize(mGridCellWidth, mGridCellHeight);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+
+void OverlayPalGuiBackend::setCellSize(QSize cellSize)
+{
+    mGridCellWidth = cellSize.width();
+    mGridCellHeight = cellSize.height();
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+
 int OverlayPalGuiBackend::spriteHeight() const
 {
     return mSpriteHeight;
@@ -541,7 +558,7 @@ void OverlayPalGuiBackend::findOptimalShift()
     Image2D image = qImageToImage2D(mInputImageIndexedBeforeShift);
     int shiftX = 0;
     int shiftY = 0;
-    Image2D shiftedImage = shiftImageOptimal(image, mBackgroundColor, GridCellWidth, GridCellHeight, 0, GridCellWidth - 1, 0, GridCellHeight - 1, shiftX, shiftY);
+    Image2D shiftedImage = shiftImageOptimal(image, mBackgroundColor, mGridCellWidth, mGridCellHeight, 0, mGridCellWidth - 1, 0, mGridCellHeight - 1, shiftX, shiftY);
     if(shiftX != mShiftX || shiftY != mShiftY)
     {
         mShiftX = shiftX;
@@ -577,6 +594,8 @@ void OverlayPalGuiBackend::startImageConversion()
         try {
             std::string conversionError = mOverlayOptimiser.convert(mImagePendingConversion,
                                                                     mBackgroundColor,
+                                                                    mGridCellWidth,
+                                                                    mGridCellHeight,
                                                                     mSpriteHeight,
                                                                     GridCellColorLimit,
                                                                     mMaxBackgroundPalettes,

--- a/src/cpp/OverlayPalGuiBackend.h
+++ b/src/cpp/OverlayPalGuiBackend.h
@@ -46,6 +46,7 @@ class OverlayPalGuiBackend : public QObject
     Q_PROPERTY(QString inputImageFilename READ inputImageFilename WRITE setInputImageFilename)
     Q_PROPERTY(int shiftX READ shiftX WRITE setShiftX NOTIFY shiftXChanged)
     Q_PROPERTY(int shiftY READ shiftY WRITE setShiftY NOTIFY shiftYChanged)
+    Q_PROPERTY(QSize cellSize READ cellSize WRITE setCellSize)
     Q_PROPERTY(int spriteHeight READ spriteHeight WRITE setSpriteHeight)
     Q_PROPERTY(int maxBackgroundPalettes READ maxBackgroundPalettes WRITE setMaxBackgroundPalettes)
     Q_PROPERTY(int maxSpritePalettes READ maxSpritePalettes WRITE setMaxSpritePalettes)
@@ -78,6 +79,8 @@ public:
     void setMapInputColors(bool mapInputColors);
     bool uniqueColors() const;
     void setUniqueColors(bool uniqueColors);
+    QSize cellSize() const;
+    void setCellSize(QSize cellSize);
     int spriteHeight() const;
     void setSpriteHeight(int spriteHeight);
     int maxBackgroundPalettes() const;
@@ -201,9 +204,9 @@ private:
     QFileSystemWatcher mInputFileWatcher;
 
     const size_t PaletteGroupSize = 4;
-    // 16x16 Nametable grid
-    const int GridCellWidth = 16;
-    const int GridCellHeight = 16;
+    // 16x16 or 8x8 Nametable grid
+    int mGridCellWidth;
+    int mGridCellHeight;
     const int GridCellColorLimit = 3;
     static const size_t HardwarePaletteSize = 64;
     static const int ScreenWidth = 256;

--- a/src/qml/const.js
+++ b/src/qml/const.js
@@ -19,3 +19,5 @@
 .pragma library
 var NumPaletteGroupsBG = 4;
 var NumPaletteGroupsSPR = 4;
+var NametablePixelWidth = 256;
+var NametablePixelHeight = 240;

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -121,6 +121,7 @@ Window {
             shiftGroupBox.enabled = true;
             optimisationSettingsGroupBox.enabled = true;
             spriteModeComboBox.enabled = true;
+            bgModeComboBox.enabled = true;
             // Set groupbox title to either success message or error string
             if(optimiser.conversionSuccessful)
             {
@@ -145,6 +146,12 @@ Window {
             dstImageCanvas.debugDestinationColorsBackground = optimiser.debugDestinationColorsBackground();
             dstImageCanvas.debugPaletteIndicesBackground = optimiser.debugPaletteIndicesBackground();
             dstImageCanvas.debugSprites = optimiser.debugSpritesOverlay();
+            // Update dst image to reflect converted image grid
+            dstImageCanvas.gridWidth = dstImageCanvas.debugPaletteIndicesBackground[0].length;
+            dstImageCanvas.gridHeight = dstImageCanvas.debugPaletteIndicesBackground.length;
+            dstImageCanvas.gridCellWidth = Const.NametablePixelWidth / dstImageCanvas.gridWidth;
+            dstImageCanvas.gridCellHeight = Const.NametablePixelHeight / dstImageCanvas.gridHeight;
+            dstImageCanvas.requestPaint();
             dstImageCanvas.inputImageUpdated();
         }
 
@@ -156,6 +163,7 @@ Window {
             shiftGroupBox.enabled = false;
             optimisationSettingsGroupBox.enabled = false;
             spriteModeComboBox.enabled = false;
+            bgModeComboBox.enabled = false;
             conversionBusy.running = true;
             dstImageGroupBox.title = "Conversion running...";
             optimiser.startImageConversion();
@@ -584,7 +592,7 @@ Window {
                 GridLayout {
                     x: 0
                     y: 7
-                    rows: 1
+                    rows: 2
                     columns: 2
 
                     Label {
@@ -598,10 +606,35 @@ Window {
                         model: ["8x16", "8x8"]
                         Layout.fillHeight: false
                         Layout.preferredHeight: 40
-                        Layout.preferredWidth: 80
+                        Layout.preferredWidth: 90
                         onCurrentIndexChanged: {
-                            console.debug(model[currentIndex])
                             optimiser.spriteHeight = (model[currentIndex] == "8x8" ? 8 : 16);
+                        }
+                        Component.onCompleted: {
+                        }
+                    }
+
+                    Label {
+                        id: bgModeLabel
+                        text: qsTr("BG")
+                        font.pointSize: 10
+                    }
+
+                    ComboBox {
+                        id: bgModeComboBox
+                        model: ["16x16", "8x8"]
+                        Layout.fillHeight: false
+                        Layout.preferredHeight: 40
+                        Layout.preferredWidth: 90
+                        onCurrentIndexChanged: {
+                            var w = (model[currentIndex] == "8x8" ? 8 : 16);
+                            var h = (model[currentIndex] == "8x8" ? 8 : 16);
+                            srcImageCanvas.gridCellWidth = w;
+                            srcImageCanvas.gridCellHeight = h;
+                            srcImageCanvas.gridWidth = Const.NametablePixelWidth / w;
+                            srcImageCanvas.gridHeight = Const.NametablePixelHeight / h;
+                            srcImageCanvas.requestPaint();
+                            optimiser.cellSize = Qt.size(w, h);
                         }
                         Component.onCompleted: {
                         }
@@ -897,6 +930,7 @@ Window {
                                 convertImageButton.enabled = false
                                 // Connect signals to start automatically
                                 spriteModeComboBox.currentValueChanged.connect(optimiser.startImageConversionWrapper);
+                                bgModeComboBox.currentValueChanged.connect(optimiser.startImageConversionWrapper);
                                 xShiftSpinBox.valueModified.connect(optimiser.startImageConversionWrapper);
                                 yShiftSpinBox.valueModified.connect(optimiser.startImageConversionWrapper);
                                 maxBackgroundPalettesSpinBox.valueModified.connect(optimiser.startImageConversionWrapper);
@@ -912,6 +946,7 @@ Window {
                                 convertImageButton.enabled = true
                                 // Disconnect signals to stop starting automatically
                                 spriteModeComboBox.currentValueChanged.disconnect(optimiser.startImageConversionWrapper);
+                                bgModeComboBox.currentValueChanged.disconnect(optimiser.startImageConversionWrapper);
                                 xShiftSpinBox.valueModified.disconnect(optimiser.startImageConversionWrapper);
                                 yShiftSpinBox.valueModified.disconnect(optimiser.startImageConversionWrapper);
                                 maxBackgroundPalettesSpinBox.valueModified.disconnect(optimiser.startImageConversionWrapper);


### PR DESCRIPTION
* Add new parameters to gridCellWidth / gridCellHeight to OverlayOptimiser::convert
* Add property cellSize to OverlayPalGuiBackend and pass width / height to OverlayOptimiser
* Multiply maxRowSize in first pass by 2 to compensate for thinner grid cell width
* Remove doubleArrayHeight function and instead initialize overlay palette indices with correct dimensions
* Add combobox for switching between 16x16 and 8x8 bg attributes to "Size mode" groupbox
* Hook up combobox to change optimiser property, display grid and conversion start (when Auto enabled)