### PR TITLE
Improve image loading checks:

### DIFF
--- a/src/cpp/OverlayPalGuiBackend.cpp
+++ b/src/cpp/OverlayPalGuiBackend.cpp
@@ -331,6 +331,17 @@ void OverlayPalGuiBackend::setInputImageFilename(const QString& inputImageFilena
 
 //---------------------------------------------------------------------------------------------------------------------
 
+QString OverlayPalGuiBackend::validateInputImage(const QString& inputImageFilenameUrl) const
+{
+    QString inputImageFilename(urlToLocal(inputImageFilenameUrl));
+    QImage image(inputImageFilename);
+    if(image.isNull())
+        return "Invalid image";
+    return "";
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+
 bool OverlayPalGuiBackend::trackInputImage() const
 {
     return mTrackInputImage;

--- a/src/cpp/OverlayPalGuiBackend.h
+++ b/src/cpp/OverlayPalGuiBackend.h
@@ -61,7 +61,8 @@ public:
     ~OverlayPalGuiBackend() override;
 
     QString inputImageFilename() const;
-    void setInputImageFilename(const QString& inputImageFilename);
+    void setInputImageFilename(const QString& inputImageFilenameUrl);
+    Q_INVOKABLE QString validateInputImage(const QString& inputImageFilenameUrl) const;
 
     int backgroundColor() const;
     void setBackgroundColor(int backgroundColor);

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -22,7 +22,7 @@ import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.3
 import QtQuick.Controls.Universal 2.0
 import QtQuick.Extras 1.4
-import QtQuick.Dialogs 1.0
+import QtQuick.Dialogs 1.1
 
 import nes.overlay.optimiser 1.0
 
@@ -880,6 +880,7 @@ Window {
                 width: 230
                 height: 200
                 title: qsTr("Output")
+                enabled: false
 
                 Button {
                     id: saveImageButton
@@ -993,6 +994,15 @@ Window {
 
             }
         }
+        MessageDialog {
+            id: invalidImageMessageDialog
+            title: "Error"
+            text: "Image file format not recognized."
+            icon: StandardIcon.Critical
+            onAccepted: {
+                visible = false;
+            }
+        }
         // Load input image dialog
         FileDialog {
             id: loadImageDialog
@@ -1003,7 +1013,16 @@ Window {
             selectExisting: true
             onAccepted: {
                 visible = false
-                optimiser.inputImageFilename = fileUrls[0]
+                var imageError = optimiser.validateInputImage(fileUrls[0]);
+                if(imageError === "")
+                {
+                    optimiser.inputImageFilename = fileUrls[0];
+                    saveGroupBox.enabled = true;
+                }
+                else
+                {
+                    invalidImageMessageDialog.visible = true;
+                }
             }
             onRejected: {
                 visible = false


### PR DESCRIPTION
* Add new function OverlayPalGuiBackend::validateInputImage to check that loading the file QImage actually works
* Use validateInputImage to pop up QML message box with error when validation failed
* Disable convert / save / export group box at application launch and only enable once validated image is loaded