### PR TITLE
Add export stats for number of background tiles / number of sprites after conversion:

### DIFF
--- a/src/cpp/Export.h
+++ b/src/cpp/Export.h
@@ -33,6 +33,7 @@ struct ExportDataNES
     std::vector<uint8_t> oamCHR;
     std::vector<uint8_t> oam;
     std::vector<uint8_t> palette;
+    static constexpr size_t TileSize = 16;
 };
 
 ExportDataNES buildExportData(const OverlayOptimiser& optimiser, int paletteMask);

--- a/src/cpp/OverlayPalGuiBackend.cpp
+++ b/src/cpp/OverlayPalGuiBackend.cpp
@@ -1123,3 +1123,11 @@ bool OverlayPalGuiBackend::writeBinaryFile(const QString& filename, const std::v
     }
     return writeBinaryFile(filename, a);
 }
+
+//---------------------------------------------------------------------------------------------------------------------
+
+int OverlayPalGuiBackend::numBackgroundTiles() const
+{
+    ExportDataNES exportData = buildExportData(mOverlayOptimiser, 0xFF);
+    return exportData.bgCHR.size() / ExportDataNES::TileSize;
+}

--- a/src/cpp/OverlayPalGuiBackend.h
+++ b/src/cpp/OverlayPalGuiBackend.h
@@ -55,6 +55,7 @@ class OverlayPalGuiBackend : public QObject
     Q_PROPERTY(QString hardwarePaletteName READ hardwarePaletteName WRITE setHardwarePaletteName)
     Q_PROPERTY(bool conversionSuccessful READ conversionSuccessful)
     Q_PROPERTY(QString conversionError READ conversionError)
+    Q_PROPERTY(int numBackgroundTiles READ numBackgroundTiles)
 
 public:
     explicit OverlayPalGuiBackend(QObject *parent = nullptr);
@@ -97,6 +98,8 @@ public:
     bool conversionSuccessful() const;
 
     const QString& conversionError() const;
+
+    int numBackgroundTiles() const;
 
     static QString imageAsBase64(const QImage& image);
 

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -121,7 +121,11 @@ Window {
             // Set groupbox title to either success message or error string
             if(optimiser.conversionSuccessful)
             {
-                dstImageGroupBox.title = "Conversion successful";
+                var numBackgroundTiles = optimiser.numBackgroundTiles;
+                var sprites = optimiser.debugSpritesOverlay();
+                dstImageGroupBox.title = "Conversion successful." +
+                                         "    BG tiles: " + numBackgroundTiles +
+                                         "    Sprites: " + sprites.length;
             }
             else
             {


### PR DESCRIPTION
* Add numBackgroundTiles property to OverlayPalGuiBackend, performing a dummy export to get BG CHR size
* Append stats for number-of-background-tiles / number-of-sprites to "Conversion successful." output message in onOutputImageChanged handler