### PR TITLE
Update cmpl2 and remove implicit loops

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ for:
       only:
         - job_name: win64
     cache:
-    - Cmpl-2-0-win.zip
+    - Cmpl-2-0-a-win.zip
 
     install:
       - set QTDIR=C:\Qt\5.15\msvc2019_64
@@ -34,15 +34,16 @@ for:
       - qmake OverlayPal.pro -spec win32-msvc "CONFIG+=qtquickcompiler"
       - nmake
     after_build:
-      - if not exist Cmpl-2-0-win.zip appveyor DownloadFile http://www.coliop.org/_download/Cmpl-2-0-win.zip
+      - if not exist Cmpl-2-0-a-win.zip appveyor DownloadFile http://www.coliop.org/_download/Cmpl-2-0-a-win.zip
       - mkdir OverlayPal-%VERSION_STRING%-win64-%CONFIGURATION%
       - cd OverlayPal-%VERSION_STRING%-win64-%CONFIGURATION%
       - copy ..\LICENSE .\
       - copy ..\release\OverlayPal.exe
       - xcopy ..\nespalettes nespalettes\
       - copy ..\src\cmpl\*.cmpl .\
-      - 7z x ..\Cmpl-2-0-win.zip
-      - rename Cmpl-2-0-win Cmpl
+      - 7z x ..\Cmpl-2-0-a-win.zip
+      - rename Cmpl-2-0-a-win Cmpl
+      - copy .\Cmpl\pyCmpl\LICENSE .\Cmpl\
       - windeployqt.exe --qmldir ..\src\qml OverlayPal.exe
       - cd ..
       - ps: 7z a OverlayPal-$env:VERSION_STRING-win64-$env:CONFIGURATION.zip OverlayPal-$env:VERSION_STRING-win64-$env:CONFIGURATION
@@ -78,6 +79,7 @@ for:
       - cp ../src/cmpl/*.cmpl ./
       - tar -xvf ../Cmpl-2-0-linux64.tar.gz
       - mv Cmpl-2-0-linux64 Cmpl
+      - cp ./Cmpl/pyCmpl/LICENSE ./Cmpl/
       - cd ..
       - tar -czvf OverlayPal-${VERSION_STRING}-linux_x64-${CONFIGURATION}.tar.gz OverlayPal-${VERSION_STRING}-linux_x64-${CONFIGURATION}
       - appveyor PushArtifact OverlayPal-${VERSION_STRING}-linux_x64-${CONFIGURATION}.tar.gz

--- a/src/cmpl/FirstPass.cmpl
+++ b/src/cmpl/FirstPass.cmpl
@@ -44,15 +44,17 @@ constraints:
     }
 
     # Constraints ensuring that a color must be in one-and-only-one of BG or overlay
-    `color_InEitherBGorOverlay_ { x in XRANGE, y in YRANGE:
-        colorsBG[x, y, COLORS] + colorsOverlay[x, y, COLORS] = layerColors[x, y, COLORS];
+    `color_InEitherBGorOverlay_ { x in XRANGE, y in YRANGE, c in COLORS:
+        colorsBG[x, y, c] + colorsOverlay[x, y, c] = layerColors[x, y, c];
     }
 
     # Constraints for occupancy (logical OR between all colors in colorsOverlay, reformulated in LP)
-    `occupancy_ { x in XRANGE, y in YRANGE:
-        `_gtColorsOverlay occupancy[x, y] >= colorsOverlay[x, y, COLORS];
+    `occupancy_lt { x in XRANGE, y in YRANGE:
         `_lt1 occupancy[x, y] <= 1;
         `_ltSUM occupancy[x, y] <= sum{ c in COLORS: colorsOverlay[x, y, c] };
+    }
+    `occupancy_gt { x in XRANGE, y in YRANGE, c in COLORS:
+        `_gtColorsOverlay occupancy[x, y] >= colorsOverlay[x, y, c];
     }
 
     # Constraints to prevent each row to have more active overlay cells above limit (approximates sprites / scanline limit)
@@ -78,8 +80,8 @@ constraints:
         sum{ c in COLORS: colorsOverlayTotal[c] } <= MAX_COLORS_OVERLAY;
 
     # Constraint for colors-subset-of-palette
-    `colorsBGmustBeSubsetOfPalette_ { x in XRANGE, y in YRANGE, p in BG_PALETTES:
-        usesPaletteBG[x, y, p] * colorsBG[x, y, COLORS] <= palettesBG[p, COLORS];
+    `colorsBGmustBeSubsetOfPalette_ { x in XRANGE, y in YRANGE, p in BG_PALETTES, c in COLORS:
+        usesPaletteBG[x, y, p] * colorsBG[x, y, c] <= palettesBG[p, c];
     }
 
     # Constraint to ensure that every BG cell's set of colors are a subset of some palette's colors

--- a/src/cmpl/SecondPass.cmpl
+++ b/src/cmpl/SecondPass.cmpl
@@ -45,16 +45,18 @@ constraints:
     }
 
     # Constraints ensuring that a color must be in one-and-only-one of grid-overlay or free-overlay
-    `color_ { x in XRANGE, y in YRANGE:
-        `InEitherGridOrFreeOverlay_ colorsOverlayGrid[x, y, COLORS] + colorsOverlayFree[x, y, COLORS] = colorsOverlay[x, y, COLORS];
-        `OverlayEqualToLayerColors_ colorsOverlay[x, y, COLORS] = layerColors[x, y, COLORS];
+    `color_ { x in XRANGE, y in YRANGE, c in COLORS:
+        `InEitherGridOrFreeOverlay_ colorsOverlayGrid[x, y, c] + colorsOverlayFree[x, y, c] = colorsOverlay[x, y, c];
+        `OverlayEqualToLayerColors_ colorsOverlay[x, y, c] = layerColors[x, y, c];
     }
 
     # Constraints for occupancy (logical OR between all colors in colorsOverlayGrid, reformulated in LP)
-    `occupancy_ { x in XRANGE, y in YRANGE:
-        `_gtColorsOverlayGrid occupancy[x, y] >= colorsOverlayGrid[x, y, COLORS];
+    `occupancy_lt { x in XRANGE, y in YRANGE:
         `_lt1 occupancy[x, y] <= 1;
         `_ltSUM occupancy[x, y] <= sum{ c in COLORS: colorsOverlayGrid[x, y, c] };
+    }
+    `occupancy_gt { x in XRANGE, y in YRANGE, c in COLORS:
+        `_gtColorsOverlayGrid occupancy[x, y] >= colorsOverlayGrid[x, y, c];
     }
 
     # Constraints row size limit (approximates sprites / scanline limit)
@@ -86,8 +88,8 @@ constraints:
         sum{ c in COLORS: colorsOverlayTotal[c] } <= MAX_COLORS_OVERLAY;
 
     # Constraint for colors-subset-of-palette
-    `colorsOverlaymustBeSubsetOfPalette_ { x in XRANGE, y in YRANGE, p in SPR_PALETTES:
-        usesPaletteOverlay[x, y, p] * colorsOverlayGrid[x, y, COLORS] <= palettesOverlay[p, COLORS];
+    `colorsOverlaymustBeSubsetOfPalette_ { x in XRANGE, y in YRANGE, p in SPR_PALETTES, c in COLORS:
+        usesPaletteOverlay[x, y, p] * colorsOverlayGrid[x, y, c] <= palettesOverlay[p, c];
     }
 
     # Constraint to ensure that every BG cell's set of colors are a subset of some palette's colors

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -918,7 +918,7 @@ Window {
 
                     SpinBox {
                         id: timeOutSpinBox
-                        to: 999
+                        to: 9999
                         value: 30
                         width: 140
                         height: 32


### PR DESCRIPTION
Update CMPL2 to include recent bugfix:
* For Windows: Download and cache Cmpl-2-0-a-win.zip archive from coliop.org
* Copy LICENSE from CMPL2'2 pyCmpl directory to CMPL2' root directory (which was missing it), as requested
* Increase maximum timeout from 999 to 9999 for CMPL debugging purposes

Remove implicit looping in .cmpl files:
* Replace all implicit loops of form array[x, y, COLORS] with array[x, y, c] and explicitly loop c over COLORS