### PR TITLE
Build OverlayPal for macOS (thanks Matthew@Kindid!)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,12 @@
 *.exe
 *.out
 *.app
+
+# Qt
+*.pro.user
+
+# Mac
+.DS_Store
+
+# CMPL
+/Cmpl*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,9 @@ environment:
   - job_name: linux_x64
     appveyor_build_worker_image: Ubuntu1804
 
+  - job_name: macOS_x64
+    appveyor_build_worker_image: macos
+
 configuration:
   - Release
 
@@ -28,21 +31,24 @@ for:
       - set PATH=%PATH%;%QTDIR%\bin;C:\Qt\5.15\msvc2019_64\bin
       - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
     build_script:
+      - if not exist Cmpl-2-0-win.zip appveyor DownloadFile http://www.coliop.org/_download/Cmpl-2-0-win.zip
+      - 7z x Cmpl-2-0-win.zip
+      - cd Cmpl-2-0-win
+      - attrib -r -s -h /S /D
+      - cd ..
       - ps: $env:VERSION_STRING = $(git describe --always --dirty=dev)
       - echo .pragma library > src\qml\version.js
       - echo var VERSION_STRING = "%VERSION_STRING%"; >> src\qml\version.js
       - qmake OverlayPal.pro -spec win32-msvc "CONFIG+=qtquickcompiler"
       - nmake
     after_build:
-      - if not exist Cmpl-2-0-win.zip appveyor DownloadFile http://www.coliop.org/_download/Cmpl-2-0-win.zip
       - mkdir OverlayPal-%VERSION_STRING%-win64-%CONFIGURATION%
       - cd OverlayPal-%VERSION_STRING%-win64-%CONFIGURATION%
       - copy ..\LICENSE .\
       - copy ..\release\OverlayPal.exe
-      - xcopy ..\nespalettes nespalettes\
-      - copy ..\src\cmpl\*.cmpl .\
-      - 7z x ..\Cmpl-2-0-win.zip
-      - rename Cmpl-2-0-win Cmpl
+      - xcopy ..\release\nespalettes nespalettes\
+      - copy ..\release\*.cmpl .\
+      - xcopy /s /i ..\release\Cmpl Cmpl\
       - windeployqt.exe --qmldir ..\src\qml OverlayPal.exe
       - cd ..
       - ps: 7z a OverlayPal-$env:VERSION_STRING-win64-$env:CONFIGURATION.zip OverlayPal-$env:VERSION_STRING-win64-$env:CONFIGURATION
@@ -63,21 +69,51 @@ for:
       - sh: sudo apt update
       - sh: sudo apt install -y libgl1-mesa-dev
     build_script:
+      - if ! [ -f Cmpl-2-0-linux64.tar.gz ]; then appveyor DownloadFile http://www.coliop.org/_download/Cmpl-2-0-linux64.tar.gz; fi
+      - tar -xvf Cmpl-2-0-linux64.tar.gz
       - VERSION_STRING=$(git describe --always --dirty=dev)
-      - echo ".pragma library" > src\qml\version.js
-      - echo "var VERSION_STRING = \"${VERSION_STRING}\";" >> src\qml\version.js
+      - echo ".pragma library" > src/qml/version.js
+      - echo "var VERSION_STRING = \"${VERSION_STRING}\";" >> src/qml/version.js
       - qmake OverlayPal.pro "CONFIG+=qtquickcompiler"
       - make
     after_build:
-      - if ! [ -f Cmpl-2-0-linux64.tar.gz ]; then appveyor DownloadFile http://www.coliop.org/_download/Cmpl-2-0-linux64.tar.gz; fi
       - mkdir OverlayPal-${VERSION_STRING}-linux_x64-${CONFIGURATION}
       - cd OverlayPal-${VERSION_STRING}-linux_x64-${CONFIGURATION}
       - cp ../LICENSE ./
       - cp ../OverlayPal ./
       - cp -r ../nespalettes ./
-      - cp ../src/cmpl/*.cmpl ./
-      - tar -xvf ../Cmpl-2-0-linux64.tar.gz
-      - mv Cmpl-2-0-linux64 Cmpl
+      - cp ../*.cmpl ./
+      - cp -r ../Cmpl ./
       - cd ..
       - tar -czvf OverlayPal-${VERSION_STRING}-linux_x64-${CONFIGURATION}.tar.gz OverlayPal-${VERSION_STRING}-linux_x64-${CONFIGURATION}
       - appveyor PushArtifact OverlayPal-${VERSION_STRING}-linux_x64-${CONFIGURATION}.tar.gz
+
+# macOS (x64)
+
+  -
+    matrix:
+      only:
+        - job_name: macOS_x64
+    cache:
+    - Cmpl-2-0-macOs-Intel.zip
+
+    install:
+      - PATH=$HOME/Qt/5.15.2/clang_64/bin:$PATH
+    build_script:
+      - VERSION_STRING=$(git describe --always --dirty=dev)
+      - mkdir OverlayPal-${VERSION_STRING}-macOS_x64-${CONFIGURATION}
+      - if ! [ -f http://www.coliop.org/_download/Cmpl-2-0-macOs-Intel.zip ]; then appveyor DownloadFile http://www.coliop.org/_download/Cmpl-2-0-macOs-Intel.zip; fi
+      - unzip Cmpl-2-0-macOs-Intel.zip
+      - echo ".pragma library" > src/qml/version.js
+      - echo "var VERSION_STRING = \"${VERSION_STRING}\";" >> src/qml/version.js
+      - qmake OverlayPal.pro "CONFIG+=qtquickcompiler"
+      - make
+    after_build:
+      - cd OverlayPal-${VERSION_STRING}-macOS_x64-${CONFIGURATION}
+      - cp ../LICENSE ./
+      - cp -r ../OverlayPal.app ./
+      - macdeployqt OverlayPal.app -qmldir=../src/qml
+      - cd ..
+      - tar -czvf OverlayPal-${VERSION_STRING}-macOS_x64-${CONFIGURATION}.tar.gz OverlayPal-${VERSION_STRING}-macOS_x64-${CONFIGURATION}
+      - appveyor PushArtifact OverlayPal-${VERSION_STRING}-macOS_x64-${CONFIGURATION}.tar.gz
+

--- a/src/cpp/ImageUtils.cpp
+++ b/src/cpp/ImageUtils.cpp
@@ -16,6 +16,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
+#include <vector>
 #include <unordered_map>
 #include <map>
 #include <tuple>

--- a/src/cpp/OverlayOptimiser.cpp
+++ b/src/cpp/OverlayOptimiser.cpp
@@ -25,6 +25,7 @@
 #include <cstdio>
 #include <array>
 #include <functional>
+#include <vector>
 
 #include "SubProcess.h"
 
@@ -137,9 +138,11 @@ void OverlayOptimiser::runCmplProgram(const std::string& inputFilename,
     outputFile.close();
     // Execute process
     std::string cmplExecutable("Cmpl/bin/cmpl");
-    std::string params;
-    params += " -i " + quoteStringOnWindows(outputFilename);
-    params += " -solutionCsv " + quoteStringOnWindows(solutionCsvFilename);
+    std::vector<std::string> params;
+    params.push_back("-i");
+    params.push_back(quoteStringOnWindows(outputFilename));
+    params.push_back("-solutionCsv");
+    params.push_back(quoteStringOnWindows(solutionCsvFilename));
     int exitCode = executeProcess(exePathFilename(cmplExecutable), params, timeOut, mWorkPath);
     if(exitCode != 0)
     {

--- a/src/cpp/OverlayOptimiser.h
+++ b/src/cpp/OverlayOptimiser.h
@@ -20,6 +20,7 @@
 #ifndef OVERLAY_OPTIMISER_H
 #define OVERLAY_OPTIMISER_H
 
+#include <string>
 #include <stdexcept>
 
 #include "ImageUtils.h"

--- a/src/cpp/OverlayPalApp.cpp
+++ b/src/cpp/OverlayPalApp.cpp
@@ -1,0 +1,79 @@
+//
+// This file is part of OverlayPal ( https://github.com/michel-iwaniec/OverlayPal )
+// Copyright (c) 2021 Michel Iwaniec.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+#include <QStandardPaths>
+#include <QDir>
+
+#include "OverlayPalApp.h"
+
+//---------------------------------------------------------------------------------------------------------------------
+
+OverlayPalApp::OverlayPalApp(int& argc, char **argv)
+    : QGuiApplication(argc, argv)
+{
+    setOrganizationName("RTC");
+    setOrganizationDomain("nodomain");
+    initFS();
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+
+QString OverlayPalApp::appStoragePath(const QString& path) const
+{
+    if(appDataFolder.isEmpty())
+    {
+        return appDataFolder;
+    }
+    else
+    {
+        if(path.isEmpty())
+        {
+            return appDataFolder;
+        }
+        else
+        {
+            // does not mkdir if it doesn't exist - please do this
+            // then you can merge the code up above
+            return appDataFolder + QDir::separator() + path;
+        }
+    }
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+
+bool OverlayPalApp::initFS()
+{
+    QDir dirAppData(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation));
+    if(!dirAppData.exists())
+    {
+        // required on macOS, and possibly iOS.
+        if(dirAppData.mkpath("."))
+        {
+            appDataFolder = dirAppData.path();
+        }
+        else
+        {
+            return false;
+        }
+    }
+    else
+    {
+        appDataFolder = dirAppData.path();
+    }
+    return true;
+}

--- a/src/cpp/OverlayPalApp.h
+++ b/src/cpp/OverlayPalApp.h
@@ -15,28 +15,26 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
+#pragma once
+#ifndef OVERLAYPALAPP_H
+#define OVERLAYPALAPP_H
 
-#include <QQmlApplicationEngine>
+#include <QGuiApplication>
 
-#include <QCoreApplication>
-#include <QQmlEngine>
-#include <QQmlComponent>
-#include <QDebug>
-
-#include "OverlayPalGuiBackend.h"
-#include "OverlayPalApp.h"
-
-int main(int argc, char *argv[])
+class OverlayPalApp : public QGuiApplication
 {
-    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    Q_OBJECT
+public:
+    OverlayPalApp(int& argc, char **argv);
 
-    OverlayPalApp app(argc, argv);
+    QString appStoragePath(const QString& path = QString()) const;
+private:
+    bool initFS();
+    //
+    QString appDataFolder;
+};
 
-    qmlRegisterType<OverlayPalGuiBackend>("nes.overlay.optimiser",1,0,"OverlayPalGuiBackend");
-    QQmlApplicationEngine engine;
-    engine.load(QUrl(QStringLiteral("qrc:/main.qml")));
-    if (engine.rootObjects().isEmpty())
-        return -1;
+#undef qApp
+#define qApp qobject_cast<OverlayPalApp *>(QCoreApplication::instance())
 
-    return app.exec();
-}
+#endif // OVERLAYPALAPP_H

--- a/src/cpp/OverlayPalGuiBackend.cpp
+++ b/src/cpp/OverlayPalGuiBackend.cpp
@@ -16,16 +16,17 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
-#include <QCoreApplication>
 #include <QtConcurrent/QtConcurrentRun>
 #include <QQmlEngine>
 #include <QUrl>
 #include <QDebug>
+#include <QStandardPaths>
 
 #include <iostream>
 #include <iomanip>
 #include <limits>
 
+#include "OverlayPalApp.h"
 #include "Export.h"
 #include "GridLayer.h"
 #include "ImageUtils.h"
@@ -103,7 +104,18 @@ OverlayPalGuiBackend::OverlayPalGuiBackend(QObject *parent):
     QObject::connect(&mInputFileWatcher, SIGNAL(fileChanged(QString)), this, SLOT(handleInputFileChanged(QString)));
     std::string executablePath = QCoreApplication::applicationDirPath().toStdString();
     mOverlayOptimiser.setExecutablePath(executablePath);
+
+#ifdef Q_OS_MACX
+    // On MacOS, use a separate Qt-provided directory for temporary data files
+    QString pathToTmp = qApp->appStoragePath();
+    mOverlayOptimiser.setWorkPath(pathToTmp.toStdString());
+#else
+    // On Windows (and GNU/Linux), put temporary data files in Cmpl/bin.
+    // This is to sidestep a weird CMPL2-bug, which prevents CMPL2 from
+    // locating files when CMPL2 is running as a subprocess.
+    // TODO: Investigate root cause of this bug.
     mOverlayOptimiser.setWorkPath(executablePath + "/" + "Cmpl/bin");
+#endif
     loadHardwarePalettes(QString(executablePath.c_str()) + QString("/nespalettes"));
     // Prevent QML engine from taking ownership of and destroying models
     QQmlEngine::setObjectOwnership(&mPaletteModel, QQmlEngine::CppOwnership);

--- a/src/cpp/SubProcess.cpp
+++ b/src/cpp/SubProcess.cpp
@@ -38,8 +38,21 @@ std::string quoteStringOnWindows(const std::string& s)
     return std::string("\"") + s + std::string("\"");
 }
 
+std::wstring mergedParams(std::vector<std::string>& params)
+{
+    size_t length = params.size();
+    std::wstring s;
+    for(size_t i = 0; i < length; i++)
+    {
+        s += std::wstring(L" ");
+        std::wstring tempS(params[i].begin(), params[i].end());
+        s += tempS;
+    }
+    return s;
+}
+
 int executeProcess(std::string exeFilename,
-                   std::string params,
+                   std::vector<std::string> params,
                    int timeOut,
                    std::string startingDirectory)
 {
@@ -53,7 +66,7 @@ int executeProcess(std::string exeFilename,
     std::wstring exeFilenameW(exeFilename.begin(), exeFilename.end());
     std::string exeSuffix(".exe");
     exeFilenameW += std::wstring(exeSuffix.begin(), exeSuffix.end());
-    std::wstring paramsW(params.begin(), params.end());
+    std::wstring paramsW = mergedParams(params);
     // Attempt to execute
     std::wstring startingDirectoryW(startingDirectory.begin(), startingDirectory.end());
 
@@ -95,27 +108,20 @@ std::string quoteStringOnWindows(const std::string& s)
     return s;
 }
 
-std::vector<char*> splitParams(std::string& params)
+std::vector<char*> splitParams(std::vector<std::string>& params)
 {
     size_t length = params.size();
     std::vector<char*> charPtrs;
     for(size_t i = 0; i < length; i++)
     {
-        if(params[i] == ' ')
-        {
-            params[i] = 0;
-            if(i > 0 && i < length - 1)
-            {
-                charPtrs.push_back(&params[i+1]);
-            }
-        }
+        charPtrs.push_back(params[i].data());
     }
     charPtrs.push_back(nullptr);
     return charPtrs;
 }
 
 int executeProcess(std::string exeFilename,
-                   std::string params,
+                   std::vector<std::string> params,
                    int timeOut,
                    std::string startingDirectory)
 {

--- a/src/cpp/SubProcess.h
+++ b/src/cpp/SubProcess.h
@@ -22,7 +22,7 @@
 
 #include <string>
 
-int executeProcess(std::string exeFilename, std::string params, int timeOut, std::string startingDirectory);
+int executeProcess(std::string exeFilename, std::vector<std::string> params, int timeOut, std::string startingDirectory);
 
 std::string quoteStringOnWindows(const std::string& s);
 

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -348,7 +348,7 @@ Window {
                         id: mapInputColorsCheckBox
                         text: qsTr("Color mapping")
                         leftPadding: 0
-                        font.pointSize: 10
+//                        font.pointSize: 10
                         enabled: true
                         checked: true
                         onCheckStateChanged: {
@@ -381,7 +381,7 @@ Window {
                         id: uniqueColorsCheckBox
                         text: qsTr("Unique colors")
                         leftPadding: 0
-                        font.pointSize: 10
+//                        font.pointSize: 10
                         enabled: true
                         checked: false
                         onCheckStateChanged: optimiser.uniqueColors = checked
@@ -390,13 +390,13 @@ Window {
                     Label {
                         id: uniqueColorsEmptyLabel
                         text: qsTr("")
-                        font.pointSize: 10
+//                        font.pointSize: 10
                     }
 
                     Label {
                         id: bgColorLabel
                         text: qsTr("Background color 0")
-                        font.pointSize: 10
+//                        font.pointSize: 10
                     }
 
                     ComboBox {
@@ -602,7 +602,7 @@ Window {
                     Label {
                         id: spriteModeLabel
                         text: qsTr("SPR")
-                        font.pointSize: 10
+//                        font.pointSize: 10
                     }
 
                     ComboBox {
@@ -623,7 +623,7 @@ Window {
                     Label {
                         id: bgModeLabel
                         text: qsTr("BG")
-                        font.pointSize: 10
+//                        font.pointSize: 10
                     }
 
                     ComboBox {
@@ -797,7 +797,9 @@ Window {
 
                     Connections {
                         target: gridCellOffRadioButton
-                        onClicked: dstImageCanvas.requestPaint()
+                        function onClicked() {
+                            dstImageCanvas.requestPaint()
+                        }
                     }
                 }
 
@@ -913,7 +915,7 @@ Window {
                     Label {
                         id: label11
                         text: qsTr("Timeout")
-                        font.pointSize: 9
+//                        font.pointSize: 9
                     }
 
                     SpinBox {
@@ -925,7 +927,7 @@ Window {
                         clip: false
                         scale: 1
                         wheelEnabled: true
-                        font.pointSize: 8
+//                        font.pointSize: 8
                         editable: true
                         onValueChanged: optimiser.timeOut = value
                     }


### PR DESCRIPTION
* Add new class OverlayPalApp (derived from QGuiApplication) to handle temporary files
* Add build script to appveyor.yml (mostly a copy-n-paste of the Linux version
* Move copying of nespalettes and .cmpl files to OverlayPal.pro so it works with local builds
* Fix file-not-found-errors by making sure to copy nespalettes and *.cmpl files into the OverlayPal.app/Contents/MacOS/
* ...and also rename-move Cmpl-2-0-macOs-Intel/Cmpl2/Coliop.app/Contents/MacOS to OverlayPal.app/Contents/Cmpl for consistency with other platforms
* Conditionally copy CMPL2 copy to app bundle / directories in QMake .pro file
* Refactor .pro file / appveyor.yml to handle copies during building for all platforms, to make local builds less crippled
* Make appveyor.yml remove hidden attributes after extraction of CMPL2 archive on Windows, to avoid QMAKE_COPY_DIR skipping Cmpl/bin/.modules
* Fix version.js file to correctly use / instead of \ on Linux / macOS
* Update executeSubProcess to handle spaces on Linux process
* Font size fixes
* Add .pro.user, .DS_Store and /Cmpl* to .gitignore

linux_x64 fixes:
* Change incorrect \ to / so version string actually works