### PR TITLE
Remove implicit looping in .cmpl files:

### DIFF
--- a/src/cmpl/FirstPass.cmpl
+++ b/src/cmpl/FirstPass.cmpl
@@ -44,15 +44,17 @@ constraints:
     }
 
     # Constraints ensuring that a color must be in one-and-only-one of BG or overlay
-    `color_InEitherBGorOverlay_ { x in XRANGE, y in YRANGE:
-        colorsBG[x, y, COLORS] + colorsOverlay[x, y, COLORS] = layerColors[x, y, COLORS];
+    `color_InEitherBGorOverlay_ { x in XRANGE, y in YRANGE, c in COLORS:
+        colorsBG[x, y, c] + colorsOverlay[x, y, c] = layerColors[x, y, c];
     }
 
     # Constraints for occupancy (logical OR between all colors in colorsOverlay, reformulated in LP)
-    `occupancy_ { x in XRANGE, y in YRANGE:
-        `_gtColorsOverlay occupancy[x, y] >= colorsOverlay[x, y, COLORS];
+    `occupancy_lt { x in XRANGE, y in YRANGE:
         `_lt1 occupancy[x, y] <= 1;
         `_ltSUM occupancy[x, y] <= sum{ c in COLORS: colorsOverlay[x, y, c] };
+    }
+    `occupancy_gt { x in XRANGE, y in YRANGE, c in COLORS:
+        `_gtColorsOverlay occupancy[x, y] >= colorsOverlay[x, y, c];
     }
 
     # Constraints to prevent each row to have more active overlay cells above limit (approximates sprites / scanline limit)
@@ -78,8 +80,8 @@ constraints:
         sum{ c in COLORS: colorsOverlayTotal[c] } <= MAX_COLORS_OVERLAY;
 
     # Constraint for colors-subset-of-palette
-    `colorsBGmustBeSubsetOfPalette_ { x in XRANGE, y in YRANGE, p in BG_PALETTES:
-        usesPaletteBG[x, y, p] * colorsBG[x, y, COLORS] <= palettesBG[p, COLORS];
+    `colorsBGmustBeSubsetOfPalette_ { x in XRANGE, y in YRANGE, p in BG_PALETTES, c in COLORS:
+        usesPaletteBG[x, y, p] * colorsBG[x, y, c] <= palettesBG[p, c];
     }
 
     # Constraint to ensure that every BG cell's set of colors are a subset of some palette's colors

--- a/src/cmpl/SecondPass.cmpl
+++ b/src/cmpl/SecondPass.cmpl
@@ -45,16 +45,18 @@ constraints:
     }
 
     # Constraints ensuring that a color must be in one-and-only-one of grid-overlay or free-overlay
-    `color_ { x in XRANGE, y in YRANGE:
-        `InEitherGridOrFreeOverlay_ colorsOverlayGrid[x, y, COLORS] + colorsOverlayFree[x, y, COLORS] = colorsOverlay[x, y, COLORS];
-        `OverlayEqualToLayerColors_ colorsOverlay[x, y, COLORS] = layerColors[x, y, COLORS];
+    `color_ { x in XRANGE, y in YRANGE, c in COLORS:
+        `InEitherGridOrFreeOverlay_ colorsOverlayGrid[x, y, c] + colorsOverlayFree[x, y, c] = colorsOverlay[x, y, c];
+        `OverlayEqualToLayerColors_ colorsOverlay[x, y, c] = layerColors[x, y, c];
     }
 
     # Constraints for occupancy (logical OR between all colors in colorsOverlayGrid, reformulated in LP)
-    `occupancy_ { x in XRANGE, y in YRANGE:
-        `_gtColorsOverlayGrid occupancy[x, y] >= colorsOverlayGrid[x, y, COLORS];
+    `occupancy_lt { x in XRANGE, y in YRANGE:
         `_lt1 occupancy[x, y] <= 1;
         `_ltSUM occupancy[x, y] <= sum{ c in COLORS: colorsOverlayGrid[x, y, c] };
+    }
+    `occupancy_gt { x in XRANGE, y in YRANGE, c in COLORS:
+        `_gtColorsOverlayGrid occupancy[x, y] >= colorsOverlayGrid[x, y, c];
     }
 
     # Constraints row size limit (approximates sprites / scanline limit)
@@ -86,8 +88,8 @@ constraints:
         sum{ c in COLORS: colorsOverlayTotal[c] } <= MAX_COLORS_OVERLAY;
 
     # Constraint for colors-subset-of-palette
-    `colorsOverlaymustBeSubsetOfPalette_ { x in XRANGE, y in YRANGE, p in SPR_PALETTES:
-        usesPaletteOverlay[x, y, p] * colorsOverlayGrid[x, y, COLORS] <= palettesOverlay[p, COLORS];
+    `colorsOverlaymustBeSubsetOfPalette_ { x in XRANGE, y in YRANGE, p in SPR_PALETTES, c in COLORS:
+        usesPaletteOverlay[x, y, p] * colorsOverlayGrid[x, y, c] <= palettesOverlay[p, c];
     }
 
     # Constraint to ensure that every BG cell's set of colors are a subset of some palette's colors


### PR DESCRIPTION
* Replace all implicit loops of form array[x, y, COLORS] with array[x, y, c] and explicitly loop c over COLORS
(works-around a bug(?) in CMPL2 where implicit looping causes constraints to be ignored)