### PR TITLE
Use linuxdeployqt for self-contained Linux execution:

### DIFF
--- a/AppDir/usr/share/applications/OverlayPal.desktop
+++ b/AppDir/usr/share/applications/OverlayPal.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Name=OverlayPal
+Comment=OverlayPal NES image converter
+Exec=OverlayPal
+Icon=OverlayPal
+Categories=Graphics;

--- a/AppDir/usr/share/icons/hicolor/128x128/apps/OverlayPal.png
+++ b/AppDir/usr/share/icons/hicolor/128x128/apps/OverlayPal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c2d23961be02253bcb2af2e2f1a19434e023da9e9afe8091a3b8be863963344
+size 1381

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,6 +63,7 @@ for:
         - job_name: linux_x64
     cache:
     - Cmpl-2-0-linux64.tar.gz
+    - linuxdeployqt-continuous-x86_64.AppImage
 
     install:
       - PATH=$HOME/Qt/5.15/gcc_64/bin:$PATH
@@ -70,6 +71,8 @@ for:
       - sh: sudo apt install -y libgl1-mesa-dev
     build_script:
       - if ! [ -f Cmpl-2-0-linux64.tar.gz ]; then appveyor DownloadFile http://www.coliop.org/_download/Cmpl-2-0-linux64.tar.gz; fi
+      - if ! [ -f linuxdeployqt-continuous-x86_64.AppImage ]; then appveyor DownloadFile https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage; fi
+      - chmod ugo+x linuxdeployqt-continuous-x86_64.AppImage
       - tar -xvf Cmpl-2-0-linux64.tar.gz
       - VERSION_STRING=$(git describe --always --dirty=dev)
       - echo ".pragma library" > src/qml/version.js
@@ -78,12 +81,15 @@ for:
       - make
     after_build:
       - mkdir OverlayPal-${VERSION_STRING}-linux_x64-${CONFIGURATION}
+      - cp -r AppDir OverlayPal-${VERSION_STRING}-linux_x64-${CONFIGURATION}/
       - cd OverlayPal-${VERSION_STRING}-linux_x64-${CONFIGURATION}
-      - cp ../LICENSE ./
-      - cp ../OverlayPal ./
-      - cp -r ../nespalettes ./
-      - cp ../*.cmpl ./
-      - cp -r ../Cmpl ./
+      - cp ../LICENSE ./AppDir/
+      - mkdir -p ./AppDir/usr/bin
+      - cp ../OverlayPal ./AppDir/usr/bin/
+      - cp -r ../nespalettes ./AppDir/usr/bin/
+      - cp ../*.cmpl ./AppDir/usr/bin/
+      - cp -r ../Cmpl ./AppDir/usr/bin/
+      - ../linuxdeployqt-continuous-x86_64.AppImage AppDir/usr/share/applications/OverlayPal.desktop -qmldir=../src/qml -ignore-glob=usr/bin/Cmpl/**
       - cd ..
       - tar -czvf OverlayPal-${VERSION_STRING}-linux_x64-${CONFIGURATION}.tar.gz OverlayPal-${VERSION_STRING}-linux_x64-${CONFIGURATION}
       - appveyor PushArtifact OverlayPal-${VERSION_STRING}-linux_x64-${CONFIGURATION}.tar.gz


### PR DESCRIPTION
* Add minimal AppDir structure to repo, including a dummy icon .png to satisfy linuxdeployqt
* Download and cache linuxdeployqt in appveyor.yml
* Change appveyor.yml to copy AppDir structure into distribution directory, and copy all files into AppDir/usr/bin
* Invoke linuxdeployqt to populate AppDir with .so libraries, qml and other things