### PR TITLE
Build Linux-x64 version of CMPL2 from source in order to restore compatibility with Ubuntu 18.04

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -74,6 +74,12 @@ for:
       - if ! [ -f linuxdeployqt-continuous-x86_64.AppImage ]; then appveyor DownloadFile https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage; fi
       - chmod ugo+x linuxdeployqt-continuous-x86_64.AppImage
       - tar -xvf Cmpl-2-0-1-linux64.tar.gz
+      - git clone https://github.com/MikeSteglich/Cmpl2.git
+      - cd Cmpl2
+      - git checkout a54a075092192e56450956ac82e722588d1bde96
+      - make
+      - cd ..
+      - cp Cmpl2/bin/cmpl Cmpl-2-0-1-linux64/bin/
       - VERSION_STRING=$(git describe --always --dirty=dev)
       - echo ".pragma library" > src/qml/version.js
       - echo "var VERSION_STRING = \"${VERSION_STRING}\";" >> src/qml/version.js


### PR DESCRIPTION
Build Linux-x64 version of CMPL2 from source in order to restore compatibility with Ubuntu 18.04:
* Clone Cmpl2 git repo and build appropriate commit
* Copy bin/cmpl executable into original extracted Cmpl 2.0.1 archive