### PR TITLE
Support not having a time-out when solving, represented as a time-out of 0

### DIFF
--- a/src/cpp/OverlayOptimiser.cpp
+++ b/src/cpp/OverlayOptimiser.cpp
@@ -133,7 +133,10 @@ void OverlayOptimiser::runCmplProgram(const std::string& inputFilename,
                               std::istreambuf_iterator<char>());
     inputFile.close();
     std::ofstream outputFile(outputFilename);
-    outputFile << "%opt cbc seconds " << timeOut << "\n";
+    if(timeOut)
+    {
+        outputFile << "%opt cbc seconds " << timeOut << "\n";
+    }
     outputFile << inputFileStr;
     outputFile.close();
     // Execute process

--- a/src/cpp/SubProcess.cpp
+++ b/src/cpp/SubProcess.cpp
@@ -82,7 +82,8 @@ int executeProcess(std::string exeFilename,
                         &pi ))
     {
         // Wait until process is finished - but no longer than 10x timeOut value
-        int timeOutMs = 1000 * timeOut;
+        // Or a ridiculously long time if timeOut is 0 (=disabled)
+        int timeOutMs = timeOut ? 1000 * timeOut : 200000000;
         uint32_t eventType = WaitForSingleObject(pi.hProcess, 10 * timeOutMs);
         if(eventType == WAIT_OBJECT_0)
         {


### PR DESCRIPTION
* Update OverlayOptimiser::runCmplProgram to omit timeout value in written .cmpl file for timeOut == 0
* Update process-timeout in Windows-version of executeProcess to have a ridiculously long wait time for timeOut == 0