### PR TITLE
Fix for redundant overlay colors when solver times out:

### DIFF
--- a/src/cpp/ImageUtils.cpp
+++ b/src/cpp/ImageUtils.cpp
@@ -185,3 +185,42 @@ void optimizeContinuity(const GridLayer& layer,
         }
     }
 }
+
+//---------------------------------------------------------------------------------------------------------------------
+
+void optimizeUnnecessaryOverlayColors(GridLayer& layerBackground,
+                                      GridLayer& layerOverlay,
+                                      Array2D<uint8_t>& paletteIndices,
+                                      uint8_t paletteIndicesOffset,
+                                      const std::vector<Colors>& palettes)
+{
+    assert(layerOverlay.width() == layerBackground.width());
+    assert(layerOverlay.height() == layerBackground.height());
+    assert(paletteIndices.width() == layerBackground.width());
+    assert(paletteIndices.height() == layerBackground.height());
+    assert(paletteIndicesOffset < palettes.size());
+    for(size_t y = 0; y < layerBackground.height(); y++)
+    {
+        for(size_t x = 0; x < layerBackground.width(); x++)
+        {
+            Colors& colorsBackground = layerBackground(x, y).colors;
+            Colors& colorsOverlay = layerOverlay(x, y).colors;
+            // Get union
+            Colors colorsAll = colorsBackground;
+            colorsAll.insert(colorsOverlay.begin(), colorsOverlay.end());
+            // If any palette is a superset of all colors, use it and
+            // move colors into background layer
+            for(size_t i = paletteIndicesOffset; i < palettes.size(); i++)
+            {
+                const Colors& paletteColors = palettes[i];
+                if(isSubSet(colorsAll, paletteColors))
+                {
+                    colorsBackground = colorsAll;
+                    colorsOverlay.clear();
+                    paletteIndices(x, y) = i;
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/src/cpp/ImageUtils.h
+++ b/src/cpp/ImageUtils.h
@@ -41,4 +41,17 @@ Image2D shiftImageOptimal(const Image2D& image2D, uint8_t backgroundColor, int c
 //
 void optimizeContinuity(const GridLayer& layer, Array2D<uint8_t>& paletteIndices, uint8_t paletteIndicesOffset, const std::vector<std::set<uint8_t>>& palettes, uint8_t backgroundColor);
 
+//
+// Move overlay colors back to background where possible, changing the palette index
+// of the background cell if needed.
+//
+// Reasons for this function is when CBC stops on a timeout. The best-solution-so-far
+// found can sometimes have obvious suboptimal results that are easy to undo here.
+//
+void optimizeUnnecessaryOverlayColors(GridLayer& layerBackground,
+                                      GridLayer& layerOverlay,
+                                      Array2D<uint8_t>& paletteIndices,
+                                      uint8_t paletteIndicesOffset,
+                                      const std::vector<Colors>& palettes);
+
 #endif // IMAGE_UTILS_H

--- a/src/cpp/OverlayOptimiser.cpp
+++ b/src/cpp/OverlayOptimiser.cpp
@@ -609,6 +609,12 @@ std::string OverlayOptimiser::convert(const Image2D& image,
                                            paletteIndicesBackground);
     if(!successPassOne)
         return "First pass failed.";
+    // Optimize easily-fixable bad cases that originate from solver getting timed out
+    optimizeUnnecessaryOverlayColors(layerBackground,
+                                     layerOverlay,
+                                     paletteIndicesBackground,
+                                     0,
+                                     palettes);
     // Split image into background and overlay
     moveOverlayColors(image, imageBackground, imageOverlay, layerOverlay, backgroundColor);
     optimizeContinuity(layerBackground, paletteIndicesBackground, 0, palettes, backgroundColor);
@@ -650,6 +656,12 @@ std::string OverlayOptimiser::convert(const Image2D& image,
                                             paletteIndicesOverlay);
     if(!successPassTwo)
         throw Error("Second pass failed.");
+    // Optimize easily-fixable bad cases that originate from solver getting timed out
+    optimizeUnnecessaryOverlayColors(layerOverlayGrid,
+                                     layerOverlayFree,
+                                     paletteIndicesOverlay,
+                                     NumBackgroundPalettes,
+                                     palettes);
     moveOverlayColors(imageOverlay, imageOverlayGrid, imageOverlayFree, layerOverlayFree, backgroundColor);
     optimizeContinuity(layerOverlayGrid, paletteIndicesOverlay, NumBackgroundPalettes, palettes, backgroundColor);
     assert(consistentLayers(imageOverlayGrid, layerOverlayGrid, palettes, paletteIndicesOverlay, backgroundColor));


### PR DESCRIPTION
* Add new function optimizeUnnecessaryOverlayColors, which moves colors overlay layer back to background layer when possible
* Call optimizeUnnecessaryOverlayColors directly after first and second pass in OverlayOptimiser::convert