### PR TITLE
Merge redundant palettes

### DIFF
--- a/src/cpp/ImageUtils.h
+++ b/src/cpp/ImageUtils.h
@@ -54,4 +54,12 @@ void optimizeUnnecessaryOverlayColors(GridLayer& layerBackground,
                                       uint8_t paletteIndicesOffset,
                                       const std::vector<Colors>& palettes);
 
+//
+// Optimize unnecessary palettes by identifying and merging two palettes that could fit into one
+//
+void optimizeUnnecessaryPalettes(Array2D<uint8_t>& paletteIndices,
+                                 uint8_t paletteIndicesOffset,
+                                 std::vector<Colors>& palettes,
+                                 size_t maxColors);
+
 #endif // IMAGE_UTILS_H

--- a/src/cpp/OverlayOptimiser.h
+++ b/src/cpp/OverlayOptimiser.h
@@ -160,7 +160,7 @@ protected:
                            std::vector<std::set<uint8_t>>& palettes,
                            Array2D<uint8_t>& paletteIndicesBackground);
 
-    void fillMissingPaletteGroups(std::vector<std::set<uint8_t>>& palettes);
+    void fillMissingPaletteGroups(std::vector<std::set<uint8_t>>& palettes, size_t numPalettes);
 
     Sprite extractSpriteWithBestPalette(Image2D& overlayImage, size_t x, size_t y, size_t spriteWidth, size_t spriteHeight, bool removePixels) const;
 


### PR DESCRIPTION
* Add new function ImageUtils.cpp:optimizeUnnecessaryPalettes which performs a palette merge whenever two palettes could fit into one
* Call optimizeUnnecessaryPalettes after first / second conversion pass to optimize background / sprite palettes