### PR TITLE
Improvements to Offset SpinBox

### DIFF
--- a/src/cpp/HardwareColorsModel.cpp
+++ b/src/cpp/HardwareColorsModel.cpp
@@ -88,7 +88,7 @@ QVariant HardwareColorsModel::data(const QModelIndex &index, int role) const
         {
             case Qt::DisplayRole:
                 return "3F";
-            case Qt::BackgroundColorRole:
+            case Qt::BackgroundRole:
                 return QColor(0, 0, 0);
             case Qt::ForegroundRole:
                 return QColor(255, 255, 255);
@@ -105,7 +105,7 @@ QVariant HardwareColorsModel::data(const QModelIndex &index, int role) const
     {
         case Qt::DisplayRole:
             return QString("%1").arg(color, 2, 16, QLatin1Char('0')).toUpper();
-        case Qt::BackgroundColorRole:
+        case Qt::BackgroundRole:
             return backgroundColor;
         case Qt::ForegroundRole:
             return foregroundTextColor(backgroundColor);
@@ -133,6 +133,6 @@ Qt::ItemFlags HardwareColorsModel::flags(const QModelIndex &index) const
 QHash<int, QByteArray> HardwareColorsModel::roleNames() const
 {
     return { {Qt::DisplayRole, "display"},
-             {Qt::BackgroundColorRole, "backgroundColor"},
+             {Qt::BackgroundRole, "backgroundColor"},
              {Qt::ForegroundRole, "foregroundColor"}};
 }

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -494,12 +494,16 @@ Window {
                     SpinBox {
                         id: xShiftSpinBox
                         x: 40
-                        to: 255
+                        from: -to
+                        to: 2*256
                         value: 0
                         leftPadding: 46
                         transformOrigin: Item.Center
                         Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
-                        onValueChanged: optimiser.shiftX = value
+                        onValueChanged: {
+                            value = ((value % 256) + 256) % 256;
+                            optimiser.shiftX = value
+                        }
                         editable: true
                     }
 
@@ -518,10 +522,14 @@ Window {
                     SpinBox {
                         id: yShiftSpinBox
                         x: 40
-                        to: 239
+                        from: -to
+                        to: 2*240
                         value: 0
                         Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
-                        onValueChanged: optimiser.shiftY = value
+                        onValueChanged: {
+                            value = ((value % 240) + 240) % 240;
+                            optimiser.shiftY = value
+                        }
                         editable: true
                     }
                 }


### PR DESCRIPTION
I've modified two files. Changes to [HardwareColorsModel.cpp](https://github.com/michel-iwaniec/OverlayPal/compare/main...Cuperino:OverlayPal:offset-improvements?expand=1#diff-109784648c666a256bf4cecaec330b7a2f1b79e18384713da78701266651558b) fix a deprecation that made OverlayPal incompatible with Qt 6. Other changes need to be done in the QML side to make OverlayPal compatible with Qt 6.

Changes to [main.qml](https://github.com/michel-iwaniec/OverlayPal/compare/main...Cuperino:OverlayPal:offset-improvements?expand=1#diff-53e5d3b300614c89cf405e579751a2a5714b922e5a2d04ba393bd152dbf5ffbe) implement the improvements suggested on issue #56. The offset SpinBoxes' ranges are extended to include negative numbers and numbers twice the maximum, and map those out of range values to valid inputs. This improves user experience by allowing them to set offset values more efficiently.