### PR TITLE
Add Banksize option to export with a maximum banksize

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,11 +124,17 @@ This allows you to save the converted image (with palette display settings appli
 
 This allows exporting the converted image (with palette display settings applied) to the binary formats used by the NES PPU hardware and other NES graphics editing tools.
 
+When generating the output files, there is an option to change the way the files are setup in order to support different mapper configurations.
+
+* Bank Size:
+  * Default - Includes all of the BG tiles in a single `.chr` file. This mode is most useful for the MMC5 mapper, as combined with the exram file, it is able to access all of the CHR banks without bank switching.
+  * 1,2,4Kb - Split into multiple `.chr` files with a maximum size of 1, 2, or 4Kb. The nametable will only reference a new bank at the start of a row, so the user can safely switch graphics during HBlank without visual corruption. Additionally, once a new bank is started, the nametable will only reference tiles from that bank (and will duplicate tiles from previous banks if they are used again)
+
 More specifically, the following files are saved:
 
 * [filename].nam file - The 1kB NES nametable data storing tile indices and 16x16 attributes selecting palettes
-* [filename].exram - Extended bits for tile indices and 8x8 attributes, matching the MMC5 exRAM layout
-* [filename]_bg.chr - The character data for the background layer
+* [filename].exram - Extended bits for tile indices and 8x8 attributes, matching the MMC5 exRAM layout. Only exported when using `Default` bank size.
+* [filename]_bg.chr - The character data for the background layer. When exporting with a maximum bank size selected, the file pattern will be [filename]\_bg\_$i.chr where $i is the bank number.
 * [filename]_spr.chr - The character data for the sprite layer
 * [filename].oam - Tile indices / positions / palette selection for sprites, encoded in NES Object Attribute Memory format
 * [filename]_palette.dat - The 32-entry palette representing NES PPU colors

--- a/src/cpp/Export.cpp
+++ b/src/cpp/Export.cpp
@@ -197,9 +197,9 @@ void buildDataNES_BGBanked(const Image2D& image,
                      int exportBankSize,
                      const Array2D<uint8_t>& paletteIndicesBackground,
                      std::vector<uint8_t>& nametable,
+                     std::vector<uint8_t>& exRAM,
                      std::vector<std::vector<uint8_t>>& chr)
 {
-    std::vector<uint8_t> exRAM{};
     exRAM.clear();
     exRAM.resize(1024);
     nametable.clear();
@@ -365,6 +365,7 @@ ExportDataNES buildExportData(const OverlayOptimiser& optimiser, int paletteMask
                         exportBankSize,
                         optimiser.debugPaletteIndicesBackground(),
                         exportData.nametable,
+                        exportData.exram,
                         exportData.bgCHR);
     }
     // Sprite OAM / CHR

--- a/src/cpp/Export.cpp
+++ b/src/cpp/Export.cpp
@@ -244,7 +244,7 @@ void buildDataNES_BGBanked(const Image2D& image,
 
         OutputTileRow(y, image, paletteMask, tileDataToIndex, paletteIndicesBackground, nametable, exRAM, chr[currentBank]);
     }
-    OutputAttributes(exRAM, nametable);
+    OutputAttributes(nametable, exRAM);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/cpp/Export.cpp
+++ b/src/cpp/Export.cpp
@@ -97,49 +97,51 @@ TileNES_8x8 extractTileNES_8x8(const Image2D& image, int paletteMask, int x, int
     return t;
 }
 
-//---------------------------------------------------------------------------------------------------------------------
+using TileMap = std::unordered_map<TileNES_8x8, size_t, TileNES_8x8_hash, TileNES_8x8_equal>;
 
-void buildDataNES_BG(const Image2D& image,
-                     int paletteMask,
-                     const Array2D<uint8_t>& paletteIndicesBackground,
-                     std::vector<uint8_t>& nametable,
-                     std::vector<uint8_t>& exRAM,
-                     std::vector<uint8_t>& chr)
+static void OutputTileRow(int y,
+                          const Image2D& image,
+                          int paletteMask,
+                          TileMap& tileDataToIndex,
+                          const Array2D<uint8_t>& paletteIndicesBackground,
+                          std::vector<uint8_t>& nametable,
+                          std::vector<uint8_t>& exRAM,
+                          std::vector<uint8_t>& chr)
 {
-    nametable.clear();
-    nametable.resize(1024);
-    exRAM.clear();
-    exRAM.resize(1024);
-    chr.clear();
-    std::unordered_map<TileNES_8x8, size_t, TileNES_8x8_hash, TileNES_8x8_equal> tileDataToIndex;
+
     int tileWidth = 8;
     int tileHeight = 8;
+    int nametableGridHeight = 30;
+    int nametableGridWidth = 32;
+    int scaleWidth = nametableGridWidth / paletteIndicesBackground.width();
+    int scaleHeight = nametableGridHeight / paletteIndicesBackground.height();
+    for(size_t x = 0; x < nametableGridWidth; x++)
+    {
+        uint8_t p = paletteIndicesBackground(x / scaleWidth, y / scaleHeight);
+        TileNES_8x8 t = extractTileNES_8x8(image, paletteMask, tileWidth * x, tileHeight * y, tileWidth, tileHeight, p);
+        if(!tileDataToIndex.count(t))
+        {
+            tileDataToIndex[t] = tileDataToIndex.size();
+            uint8_t* p = reinterpret_cast<uint8_t*>(&t.p0);
+            for(int y = 0; y < 2 * tileHeight; y++)
+            {
+                chr.push_back(p[y]);
+            }
+        }
+        int tileIndex = tileDataToIndex[t];
+        nametable[nametableGridWidth * y + x] = tileIndex & 0xFF;
+        exRAM[nametableGridWidth * y + x] = (p << 6) | (tileIndex >> 8);
+    }
+}
+
+static void OutputAttributes(std::vector<uint8_t>& nametable,
+                             std::vector<uint8_t>& exRAM)
+{
+
     int nametableGridWidth = 32;
     int nametableGridHeight = 30;
     int attributeGridWidth = 16;
     int attributeGridHeight = 15;
-    int scaleWidth = nametableGridWidth / paletteIndicesBackground.width();
-    int scaleHeight = nametableGridHeight / paletteIndicesBackground.height();
-    for(size_t y = 0; y < nametableGridHeight; y++)
-    {
-        for(size_t x = 0; x < nametableGridWidth; x++)
-        {
-            uint8_t p = paletteIndicesBackground(x / scaleWidth, y / scaleHeight);
-            TileNES_8x8 t = extractTileNES_8x8(image, paletteMask, tileWidth * x, tileHeight * y, tileWidth, tileHeight, p);
-            if(!tileDataToIndex.count(t))
-            {
-                tileDataToIndex[t] = tileDataToIndex.size();
-                uint8_t* p = reinterpret_cast<uint8_t*>(&t.p0);
-                for(int y = 0; y < 2 * tileHeight; y++)
-                {
-                    chr.push_back(p[y]);
-                }
-            }
-            int tileIndex = tileDataToIndex[t];
-            nametable[nametableGridWidth * y + x] = tileIndex & 0xFF;
-            exRAM[nametableGridWidth * y + x] = (p << 6) | (tileIndex >> 8);
-        }
-    }
     // Write non-MMC5 16x16 attributes
     Array2D<uint8_t> colorTable(attributeGridWidth, attributeGridHeight + 1);
     for(int y = 0; y < attributeGridHeight; y++)
@@ -163,6 +165,86 @@ void buildDataNES_BG(const Image2D& image,
             nametable[attributesOffset + 8 * y + x] = a;
         }
     }
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+
+void buildDataNES_BG(const Image2D& image,
+                     int paletteMask,
+                     const Array2D<uint8_t>& paletteIndicesBackground,
+                     std::vector<uint8_t>& nametable,
+                     std::vector<uint8_t>& exRAM,
+                     std::vector<uint8_t>& chr)
+{
+    nametable.clear();
+    nametable.resize(1024);
+    exRAM.clear();
+    exRAM.resize(1024);
+    chr.clear();
+    TileMap tileDataToIndex;
+    constexpr int nametableGridHeight = 30;
+    for(size_t y = 0; y < nametableGridHeight; y++)
+    {
+        OutputTileRow(y, image, paletteMask, tileDataToIndex, paletteIndicesBackground, nametable, exRAM, chr);
+    }
+    OutputAttributes(nametable, exRAM);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+
+void buildDataNES_BGBanked(const Image2D& image,
+                     int paletteMask,
+                     int exportBankSize,
+                     const Array2D<uint8_t>& paletteIndicesBackground,
+                     std::vector<uint8_t>& nametable,
+                     std::vector<std::vector<uint8_t>>& chr)
+{
+    std::vector<uint8_t> exRAM{};
+    exRAM.clear();
+    exRAM.resize(1024);
+    nametable.clear();
+    nametable.resize(1024);
+    chr.clear();
+    chr.push_back({});
+    using TileMap = std::unordered_map<TileNES_8x8, size_t, TileNES_8x8_hash, TileNES_8x8_equal>;
+    TileMap tileDataToIndex = {};
+    int currentBank = 0;
+    int tileWidth = 8;
+    int tileHeight = 8;
+    int nametableGridWidth = 32;
+    int nametableGridHeight = 30;
+    int scaleWidth = nametableGridWidth / paletteIndicesBackground.width();
+    int scaleHeight = nametableGridHeight / paletteIndicesBackground.height();
+    for(size_t y = 0; y < nametableGridHeight; y++)
+    {
+        // make a copy of the hash map
+        auto bankMap = tileDataToIndex;
+        bool nextBank = false;
+        // loop through this row of tiles to see if it can fit in the current bank
+        for(size_t x = 0; x < nametableGridWidth; x++)
+        {
+            uint8_t p = paletteIndicesBackground(x / scaleWidth, y / scaleHeight);
+            TileNES_8x8 t = extractTileNES_8x8(image, paletteMask, tileWidth * x, tileHeight * y, tileWidth, tileHeight, p);
+            if(!bankMap.count(t))
+            {
+                bankMap[t] = bankMap.size();
+            }
+            if (bankMap.size() > (exportBankSize / 16)) {
+                nextBank = true;
+                break;
+            }
+        }
+
+        // if it overflows this bank, bump to the next bank and start fresh
+        if (nextBank) {
+            tileDataToIndex.clear();
+            currentBank++;
+            chr.push_back({});
+        }
+
+        OutputTileRow(y, image, paletteMask, tileDataToIndex, paletteIndicesBackground, nametable, exRAM, chr[currentBank]);
+    }
+    OutputAttributes(exRAM, nametable);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -261,17 +343,30 @@ void buildDataNES_palette(const std::vector<std::set<uint8_t> > &palettes, uint8
 
 //---------------------------------------------------------------------------------------------------------------------
 
-ExportDataNES buildExportData(const OverlayOptimiser& optimiser, int paletteMask)
+ExportDataNES buildExportData(const OverlayOptimiser& optimiser, int paletteMask, int exportBankSize)
 {
     ExportDataNES exportData;
     Image2D image = optimiser.outputImage();
     // Background nametable / CHR
-    buildDataNES_BG(image,
-                    paletteMask,
-                    optimiser.debugPaletteIndicesBackground(),
-                    exportData.nametable,
-                    exportData.exram,
-                    exportData.bgCHR);
+    // if there is no bank size, then we can
+    if (exportBankSize == 0) {
+        exportData.bgCHR.clear();
+        exportData.bgCHR.resize(1);
+        exportData.bgCHR[0] = {};
+        buildDataNES_BG(image,
+                        paletteMask,
+                        optimiser.debugPaletteIndicesBackground(),
+                        exportData.nametable,
+                        exportData.exram,
+                        exportData.bgCHR[0]);
+    } else {
+        buildDataNES_BGBanked(image,
+                        paletteMask,
+                        exportBankSize,
+                        optimiser.debugPaletteIndicesBackground(),
+                        exportData.nametable,
+                        exportData.bgCHR);
+    }
     // Sprite OAM / CHR
     if(optimiser.spriteHeight() == 16)
         buildDataNES_OAM_8x16(image, paletteMask, optimiser.spritesOverlay(), exportData.oam, exportData.oamCHR);

--- a/src/cpp/Export.h
+++ b/src/cpp/Export.h
@@ -29,13 +29,13 @@ struct ExportDataNES
 {
     std::vector<uint8_t> nametable;
     std::vector<uint8_t> exram;
-    std::vector<uint8_t> bgCHR;
+    std::vector<std::vector<uint8_t>> bgCHR;
     std::vector<uint8_t> oamCHR;
     std::vector<uint8_t> oam;
     std::vector<uint8_t> palette;
     static constexpr size_t TileSize = 16;
 };
 
-ExportDataNES buildExportData(const OverlayOptimiser& optimiser, int paletteMask);
+ExportDataNES buildExportData(const OverlayOptimiser& optimiser, int paletteMask, int exportBankSize);
 
 #endif // EXPORT_H

--- a/src/cpp/OverlayOptimiser.cpp
+++ b/src/cpp/OverlayOptimiser.cpp
@@ -27,6 +27,7 @@
 #include <functional>
 #include <vector>
 
+#include "ImageUtils.h"
 #include "SubProcess.h"
 
 #include "OverlayOptimiser.h"

--- a/src/cpp/OverlayOptimiser.h
+++ b/src/cpp/OverlayOptimiser.h
@@ -20,10 +20,10 @@
 #ifndef OVERLAY_OPTIMISER_H
 #define OVERLAY_OPTIMISER_H
 
+#include <functional>
 #include <string>
 #include <stdexcept>
 
-#include "ImageUtils.h"
 #include "GridLayer.h"
 #include "Array2D.h"
 #include "Sprite.h"

--- a/src/cpp/OverlayPalGuiBackend.cpp
+++ b/src/cpp/OverlayPalGuiBackend.cpp
@@ -1154,13 +1154,12 @@ void OverlayPalGuiBackend::exportOutputImage(QString filename, int paletteMask)
     // For bgCHR, if we have more than one in the export, then we add the index of the nametable
     // to the filename when saving.
     for (int i = 0; i < exportData.bgCHR.size(); ++i) {
-        const auto idx = (exportData.bgCHR.size() == 1) ? QString() : QString("_%1").arg(i);
+        const auto idx = QString("_%1").arg(i);
         QString bgCHRFilename = QString("%1/%2_bg%3.chr").arg(fi.path(), fi.baseName(), idx);
         writeBinaryFile(bgCHRFilename, exportData.bgCHR[i]);
     }
-    if (!exportData.exram.empty()) {
-        writeBinaryFile(exramFilename, exportData.exram);
-    }
+
+    writeBinaryFile(exramFilename, exportData.exram);
     writeBinaryFile(nametableFilename, exportData.nametable);
     writeBinaryFile(oamFilename, exportData.oam);
     writeBinaryFile(sprCHRFilename, exportData.oamCHR);

--- a/src/cpp/OverlayPalGuiBackend.h
+++ b/src/cpp/OverlayPalGuiBackend.h
@@ -57,6 +57,7 @@ class OverlayPalGuiBackend : public QObject
     Q_PROPERTY(bool conversionSuccessful READ conversionSuccessful)
     Q_PROPERTY(QString conversionError READ conversionError)
     Q_PROPERTY(int numBackgroundTiles READ numBackgroundTiles)
+    Q_PROPERTY(int exportBankSize READ exportBankSize WRITE setExportBankSize)
 
 public:
     explicit OverlayPalGuiBackend(QObject *parent = nullptr);
@@ -95,6 +96,8 @@ public:
     void setMaxSpritePalettes(int maxSpritePalettes);
     int maxSpritesPerScanline() const;
     void setMaxSpritesPerScanline(int maxSpritesPerScanline);
+    int exportBankSize() const;
+    void setExportBankSize(int exportBankSize);
 
     int timeOut() const;
     void setTimeOut(int timeOut);
@@ -194,6 +197,7 @@ private:
     int mMaxBackgroundPalettes;
     int mMaxSpritePalettes;
     int mMaxSpritesPerScanline;
+    int mExportBankSize;
     bool mMapInputColors;
     uint8_t mBackgroundColor;
     bool mAutoBackgroundColor;

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -33,7 +33,7 @@ import "version.js" as Version
 Window {
     id: window
     visible: true
-    width: 1830
+    width: 1820
     height: 984
     title: qsTr("OverlayPal (" + Version.VERSION_STRING + ") https://github.com/michel-iwaniec/OverlayPal")
     property var loaderProxy: null
@@ -43,11 +43,11 @@ Window {
         // Adapt window to either a 1080p screen or a less-than-1080p-screen.
         // TODO: Scaling choice needs to be more flexible going forward.
         var activePortion = 0.915;
-        var optimalWidth = 1950;
+        var optimalWidth = 1920;
         var optimalHeight = 1080;
         var zoom = 3;
         var uiScale = 1.0;
-        if(Screen.width < optimalWidth)
+        if(Screen.width < 1920)
         {
             optimalWidth = Screen.width;
             optimalHeight = Screen.height;
@@ -74,18 +74,18 @@ Window {
         id: dropArea;
         anchors.fill: parent
         onEntered: (drag) => {
-                       if(drag.hasUrls && drag.urls.length === 1)
-                       {
-                           drag.accepted = true;
-                       }
-                       else
-                       {
-                           drag.accepted = false;
-                       }
-                   }
+            if(drag.hasUrls && drag.urls.length === 1)
+            {
+                drag.accepted = true;
+            }
+            else
+            {
+                drag.accepted = false;
+            }
+        }
         onDropped: (drop) => {
-                       loadImage(drop.urls[0]);
-                   }
+            loadImage(drop.urls[0]);
+        }
     }
 
     OverlayPalGuiBackend {
@@ -142,8 +142,8 @@ Window {
                 var numBackgroundTiles = optimiser.numBackgroundTiles;
                 var sprites = optimiser.debugSpritesOverlay();
                 dstImageGroupBox.title = "Conversion successful." +
-                        "    BG tiles: " + numBackgroundTiles +
-                        "    Sprites: " + sprites.length;
+                                         "    BG tiles: " + numBackgroundTiles +
+                                         "    Sprites: " + sprites.length;
             }
             else
             {
@@ -830,7 +830,7 @@ Window {
 
             GroupBox {
                 id: gridCellDebugGroupBox
-                width: 360
+                width: 344
                 height: 200
                 spacing: 6
                 title: qsTr("Grid Cell Debug Mode")
@@ -931,152 +931,124 @@ Window {
 
             GroupBox {
                 id: saveGroupBox
-                width: 245
+                width: 262
                 height: 200
-                padding: 0
-                leftPadding: 0
-                topPadding: 19
                 title: qsTr("Output")
                 enabled: false
 
-                Column {
-                    id: column1
-                    width: 230
-                    height: 200
-                    rightPadding: 0
-                    leftPadding: 5
-                    topPadding: 10
-                    spacing: 3
+                GridLayout {
+                    x: 0
+                    y: 2
+                    rows: 4
+                    columns: 2
+                    rowSpacing: 4
 
-                    RowLayout {
-                        height: 36
-                        spacing: 8
-
-                        Button {
-                            id: convertImageButton
-                            y: 0
-                            height: 32
-                            text: qsTr("Convert")
-                            Layout.preferredHeight: 36
-                            Layout.preferredWidth: 103
-                            onClicked: {
-                                optimiser.startImageConversionWrapper();
-                            }
+                    Button {
+                        id: convertImageButton
+                        Layout.preferredHeight: 36
+                        text: qsTr("Convert")
+                        onClicked: {
+                            optimiser.startImageConversionWrapper();
                         }
+                    }
 
-                        CheckBox {
-                            id: autoConversionCheckBox
-                            height: 32
-                            text: qsTr("Auto")
-                            antialiasing: true
-                            onCheckedChanged: {
-                                if(checked)
-                                {
-                                    // Disable manual conversion button
-                                    convertImageButton.enabled = false
-                                    // Connect signals to start automatically
-                                    spriteModeComboBox.currentValueChanged.connect(optimiser.startImageConversionWrapper);
-                                    bgModeComboBox.currentValueChanged.connect(optimiser.startImageConversionWrapper);
-                                    xShiftSpinBox.valueModified.connect(optimiser.startImageConversionWrapper);
-                                    yShiftSpinBox.valueModified.connect(optimiser.startImageConversionWrapper);
-                                    maxBackgroundPalettesSpinBox.valueModified.connect(optimiser.startImageConversionWrapper);
-                                    maxSpritePalettesSpinBox.valueModified.connect(optimiser.startImageConversionWrapper);
-                                    maxSpritesPerScanlineSpinBox.valueModified.connect(optimiser.startImageConversionWrapper);
-                                    optimiser.shiftXChanged.connect(optimiser.startImageConversionWrapper);
-                                    optimiser.shiftYChanged.connect(optimiser.startImageConversionWrapper);
-                                    optimiser.inputImageChanged.connect(optimiser.startImageConversionWrapper);
-                                }
-                                else
-                                {
-                                    // Re-enable manual conversion button
-                                    convertImageButton.enabled = true
-                                    // Disconnect signals to stop starting automatically
-                                    spriteModeComboBox.currentValueChanged.disconnect(optimiser.startImageConversionWrapper);
-                                    bgModeComboBox.currentValueChanged.disconnect(optimiser.startImageConversionWrapper);
-                                    xShiftSpinBox.valueModified.disconnect(optimiser.startImageConversionWrapper);
-                                    yShiftSpinBox.valueModified.disconnect(optimiser.startImageConversionWrapper);
-                                    maxBackgroundPalettesSpinBox.valueModified.disconnect(optimiser.startImageConversionWrapper);
-                                    maxSpritePalettesSpinBox.valueModified.disconnect(optimiser.startImageConversionWrapper);
-                                    maxSpritesPerScanlineSpinBox.valueModified.disconnect(optimiser.startImageConversionWrapper);
-                                    optimiser.shiftXChanged.disconnect(optimiser.startImageConversionWrapper);
-                                    optimiser.shiftYChanged.disconnect(optimiser.startImageConversionWrapper);
-                                    optimiser.inputImageChanged.disconnect(optimiser.startImageConversionWrapper);
-                                }
+                    CheckBox {
+                        id: autoConversionCheckBox
+                        Layout.preferredHeight: 36
+                        text: qsTr("Auto")
+                        antialiasing: true
+                        onCheckedChanged: {
+                            if(checked)
+                            {
+                                // Disable manual conversion button
+                                convertImageButton.enabled = false
+                                // Connect signals to start automatically
+                                spriteModeComboBox.currentValueChanged.connect(optimiser.startImageConversionWrapper);
+                                bgModeComboBox.currentValueChanged.connect(optimiser.startImageConversionWrapper);
+                                xShiftSpinBox.valueModified.connect(optimiser.startImageConversionWrapper);
+                                yShiftSpinBox.valueModified.connect(optimiser.startImageConversionWrapper);
+                                maxBackgroundPalettesSpinBox.valueModified.connect(optimiser.startImageConversionWrapper);
+                                maxSpritePalettesSpinBox.valueModified.connect(optimiser.startImageConversionWrapper);
+                                maxSpritesPerScanlineSpinBox.valueModified.connect(optimiser.startImageConversionWrapper);
+                                optimiser.shiftXChanged.connect(optimiser.startImageConversionWrapper);
+                                optimiser.shiftYChanged.connect(optimiser.startImageConversionWrapper);
+                                optimiser.inputImageChanged.connect(optimiser.startImageConversionWrapper);
+                            }
+                            else
+                            {
+                                // Re-enable manual conversion button
+                                convertImageButton.enabled = true
+                                // Disconnect signals to stop starting automatically
+                                spriteModeComboBox.currentValueChanged.disconnect(optimiser.startImageConversionWrapper);
+                                bgModeComboBox.currentValueChanged.disconnect(optimiser.startImageConversionWrapper);
+                                xShiftSpinBox.valueModified.disconnect(optimiser.startImageConversionWrapper);
+                                yShiftSpinBox.valueModified.disconnect(optimiser.startImageConversionWrapper);
+                                maxBackgroundPalettesSpinBox.valueModified.disconnect(optimiser.startImageConversionWrapper);
+                                maxSpritePalettesSpinBox.valueModified.disconnect(optimiser.startImageConversionWrapper);
+                                maxSpritesPerScanlineSpinBox.valueModified.disconnect(optimiser.startImageConversionWrapper);
+                                optimiser.shiftXChanged.disconnect(optimiser.startImageConversionWrapper);
+                                optimiser.shiftYChanged.disconnect(optimiser.startImageConversionWrapper);
+                                optimiser.inputImageChanged.disconnect(optimiser.startImageConversionWrapper);
                             }
                         }
                     }
-                    RowLayout {
-                        width: 184
-                        height: 36
-                        spacing: 8
 
-                        Label {
-                            id: label11
-                            text: qsTr("Timeout")
+                    Label {
+                        id: label11
+                        text: qsTr("Timeout")
+                    }
+
+                    SpinBox {
+                        id: timeOutSpinBox
+                        to: 999
+                        value: 30
+			Layout.preferredWidth: 120
+                        Layout.preferredHeight: 36
+                        clip: false
+                        scale: 1
+                        wheelEnabled: true
+                        editable: true
+                        onValueChanged: optimiser.timeOut = value
+                    }
+
+                    Label {
+                        id: label12
+                        text: qsTr("BG Bank Size")
+                    }
+
+                    ComboBox {
+                        id: exportBankSizeComboBox
+                        enabled: false
+                        model: ["Off", "64 (1kB)", "128 (2kB)", "256 (4kB)"]
+                        Layout.fillHeight: false
+			Layout.preferredWidth: 120
+                        Layout.preferredHeight: 36
+                        onCurrentIndexChanged: {
+                            const lookup = { "Off" : 0x0000, "64 (1kB)" : 0x0400, "128 (2kB)" :0x0800, "256 (4kB)" : 0x1000};
+                            optimiser.exportBankSize = lookup[model[currentIndex]];
                         }
-
-                        SpinBox {
-                            id: timeOutSpinBox
-                            to: 999
-                            value: 30
-                            width: 140
-                            height: 32
-                            clip: false
-                            scale: 1
-                            wheelEnabled: true
-                            editable: true
-                            onValueChanged: optimiser.timeOut = value
+                        Component.onCompleted: {
                         }
                     }
-                    RowLayout {
-
-                        Label {
-                            id: label12
-                            text: qsTr("Bank Size")
+                    Button {
+                        id: saveImageButton
+                        Layout.preferredHeight: 36
+                        text: qsTr("Save PNG...")
+                        Component.onCompleted: {
+                            saveImageButton.onClicked.connect(saveConvertedDialog.openDialog);
                         }
-                        ComboBox {
-                            id: exportBankSizeComboBox
-                            x: 0
-                            width: 0
-                            Layout.fillWidth: true
-                            enabled: false
-                            model: ["Default", "1kb", "2kb", "4kb"]
-                            Layout.fillHeight: false
-                            Layout.preferredHeight: 40
-                            Layout.preferredWidth: 90
-                            onCurrentIndexChanged: {
-                                const lookup = {"Default": 0, "1kb": 0x400, "2kb": 0x800, "4kb": 0x1000};
-                                optimiser.exportBankSize = lookup[model[currentIndex]];
-                            }
-                            Component.onCompleted: {
-                            }
-                        }
+                        enabled: false
                     }
-                    RowLayout {
-                        Button {
-                            id: saveImageButton
-                            x: 0
-                            y: 88
-                            width: 206
-                            height: 32
-                            text: qsTr("Save converted PNG...")
-                            Component.onCompleted: {
-                                saveImageButton.onClicked.connect(saveConvertedDialog.openDialog);
-                            }
-                            enabled: false
+
+                    Button {
+                        id: exportImageButton
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: 36
+                        text: qsTr("Export...")
+                        Component.onCompleted: {
+                            exportImageButton.onClicked.connect(exportConvertedDialog.openDialog);
                         }
-                        Button {
-                            id: exportImageButton
-                            x: 0
-                            y: 124
-                            width: 206
-                            height: 32
-                            text: qsTr("Export...")
-                            Component.onCompleted: {
-                                exportImageButton.onClicked.connect(exportConvertedDialog.openDialog);
-                            }
-                            enabled: false
-                        }
+                        enabled: false
                     }
                 }
 

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -33,7 +33,7 @@ import "version.js" as Version
 Window {
     id: window
     visible: true
-    width: 1820
+    width: 1830
     height: 984
     title: qsTr("OverlayPal (" + Version.VERSION_STRING + ") https://github.com/michel-iwaniec/OverlayPal")
     property var loaderProxy: null
@@ -43,11 +43,11 @@ Window {
         // Adapt window to either a 1080p screen or a less-than-1080p-screen.
         // TODO: Scaling choice needs to be more flexible going forward.
         var activePortion = 0.915;
-        var optimalWidth = 1920;
+        var optimalWidth = 1950;
         var optimalHeight = 1080;
         var zoom = 3;
         var uiScale = 1.0;
-        if(Screen.width < 1920)
+        if(Screen.width < optimalWidth)
         {
             optimalWidth = Screen.width;
             optimalHeight = Screen.height;
@@ -74,18 +74,18 @@ Window {
         id: dropArea;
         anchors.fill: parent
         onEntered: (drag) => {
-            if(drag.hasUrls && drag.urls.length === 1)
-            {
-                drag.accepted = true;
-            }
-            else
-            {
-                drag.accepted = false;
-            }
-        }
+                       if(drag.hasUrls && drag.urls.length === 1)
+                       {
+                           drag.accepted = true;
+                       }
+                       else
+                       {
+                           drag.accepted = false;
+                       }
+                   }
         onDropped: (drop) => {
-            loadImage(drop.urls[0]);
-        }
+                       loadImage(drop.urls[0]);
+                   }
     }
 
     OverlayPalGuiBackend {
@@ -142,8 +142,8 @@ Window {
                 var numBackgroundTiles = optimiser.numBackgroundTiles;
                 var sprites = optimiser.debugSpritesOverlay();
                 dstImageGroupBox.title = "Conversion successful." +
-                                         "    BG tiles: " + numBackgroundTiles +
-                                         "    Sprites: " + sprites.length;
+                        "    BG tiles: " + numBackgroundTiles +
+                        "    Sprites: " + sprites.length;
             }
             else
             {
@@ -174,6 +174,7 @@ Window {
             // Enable save/export now that output image is valid
             saveImageButton.enabled = true;
             exportImageButton.enabled = true;
+            exportBankSizeComboBox.enabled = true;
         }
 
         function startImageConversionWrapper()
@@ -930,117 +931,151 @@ Window {
 
             GroupBox {
                 id: saveGroupBox
-                width: 230
+                width: 245
                 height: 200
+                padding: 0
+                leftPadding: 0
+                topPadding: 19
                 title: qsTr("Output")
                 enabled: false
 
-                Button {
-                    id: saveImageButton
-                    x: 0
-                    y: 88
-                    width: 206
-                    height: 32
-                    text: qsTr("Save converted PNG...")
-                    Component.onCompleted: {
-                        saveImageButton.onClicked.connect(saveConvertedDialog.openDialog);
-                    }
-                    enabled: false
-                }
-                Button {
-                    id: exportImageButton
-                    x: 0
-                    y: 124
-                    width: 206
-                    height: 32
-                    text: qsTr("Export...")
-                    Component.onCompleted: {
-                        exportImageButton.onClicked.connect(exportConvertedDialog.openDialog);
-                    }
-                    enabled: false
-                }
-                RowLayout {
-                    x: 0
-                    y: 44
-                    width: 184
-                    height: 36
-                    spacing: 8
+                Column {
+                    id: column1
+                    width: 230
+                    height: 200
+                    rightPadding: 0
+                    leftPadding: 5
+                    topPadding: 10
+                    spacing: 3
 
-                    Label {
-                        id: label11
-                        text: qsTr("Timeout")
-                    }
+                    RowLayout {
+                        height: 36
+                        spacing: 8
 
-                    SpinBox {
-                        id: timeOutSpinBox
-                        to: 999
-                        value: 30
-                        width: 140
-                        height: 32
-                        clip: false
-                        scale: 1
-                        wheelEnabled: true
-                        editable: true
-                        onValueChanged: optimiser.timeOut = value
-                    }
-                }
+                        Button {
+                            id: convertImageButton
+                            y: 0
+                            height: 32
+                            text: qsTr("Convert")
+                            Layout.preferredHeight: 36
+                            Layout.preferredWidth: 103
+                            onClicked: {
+                                optimiser.startImageConversionWrapper();
+                            }
+                        }
 
-                RowLayout {
-                    x: 0
-                    y: 0
-                    height: 36
-                    spacing: 8
-
-                    Button {
-                        id: convertImageButton
-                        y: 0
-                        height: 32
-                        text: qsTr("Convert")
-                        Layout.preferredHeight: 36
-                        Layout.preferredWidth: 103
-                        onClicked: {
-                            optimiser.startImageConversionWrapper();
+                        CheckBox {
+                            id: autoConversionCheckBox
+                            height: 32
+                            text: qsTr("Auto")
+                            antialiasing: true
+                            onCheckedChanged: {
+                                if(checked)
+                                {
+                                    // Disable manual conversion button
+                                    convertImageButton.enabled = false
+                                    // Connect signals to start automatically
+                                    spriteModeComboBox.currentValueChanged.connect(optimiser.startImageConversionWrapper);
+                                    bgModeComboBox.currentValueChanged.connect(optimiser.startImageConversionWrapper);
+                                    xShiftSpinBox.valueModified.connect(optimiser.startImageConversionWrapper);
+                                    yShiftSpinBox.valueModified.connect(optimiser.startImageConversionWrapper);
+                                    maxBackgroundPalettesSpinBox.valueModified.connect(optimiser.startImageConversionWrapper);
+                                    maxSpritePalettesSpinBox.valueModified.connect(optimiser.startImageConversionWrapper);
+                                    maxSpritesPerScanlineSpinBox.valueModified.connect(optimiser.startImageConversionWrapper);
+                                    optimiser.shiftXChanged.connect(optimiser.startImageConversionWrapper);
+                                    optimiser.shiftYChanged.connect(optimiser.startImageConversionWrapper);
+                                    optimiser.inputImageChanged.connect(optimiser.startImageConversionWrapper);
+                                }
+                                else
+                                {
+                                    // Re-enable manual conversion button
+                                    convertImageButton.enabled = true
+                                    // Disconnect signals to stop starting automatically
+                                    spriteModeComboBox.currentValueChanged.disconnect(optimiser.startImageConversionWrapper);
+                                    bgModeComboBox.currentValueChanged.disconnect(optimiser.startImageConversionWrapper);
+                                    xShiftSpinBox.valueModified.disconnect(optimiser.startImageConversionWrapper);
+                                    yShiftSpinBox.valueModified.disconnect(optimiser.startImageConversionWrapper);
+                                    maxBackgroundPalettesSpinBox.valueModified.disconnect(optimiser.startImageConversionWrapper);
+                                    maxSpritePalettesSpinBox.valueModified.disconnect(optimiser.startImageConversionWrapper);
+                                    maxSpritesPerScanlineSpinBox.valueModified.disconnect(optimiser.startImageConversionWrapper);
+                                    optimiser.shiftXChanged.disconnect(optimiser.startImageConversionWrapper);
+                                    optimiser.shiftYChanged.disconnect(optimiser.startImageConversionWrapper);
+                                    optimiser.inputImageChanged.disconnect(optimiser.startImageConversionWrapper);
+                                }
+                            }
                         }
                     }
+                    RowLayout {
+                        width: 184
+                        height: 36
+                        spacing: 8
 
-                    CheckBox {
-                        id: autoConversionCheckBox
-                        height: 32
-                        text: qsTr("Auto")
-                        antialiasing: true
-                        onCheckedChanged: {
-                            if(checked)
-                            {
-                                // Disable manual conversion button
-                                convertImageButton.enabled = false
-                                // Connect signals to start automatically
-                                spriteModeComboBox.currentValueChanged.connect(optimiser.startImageConversionWrapper);
-                                bgModeComboBox.currentValueChanged.connect(optimiser.startImageConversionWrapper);
-                                xShiftSpinBox.valueModified.connect(optimiser.startImageConversionWrapper);
-                                yShiftSpinBox.valueModified.connect(optimiser.startImageConversionWrapper);
-                                maxBackgroundPalettesSpinBox.valueModified.connect(optimiser.startImageConversionWrapper);
-                                maxSpritePalettesSpinBox.valueModified.connect(optimiser.startImageConversionWrapper);
-                                maxSpritesPerScanlineSpinBox.valueModified.connect(optimiser.startImageConversionWrapper);
-                                optimiser.shiftXChanged.connect(optimiser.startImageConversionWrapper);
-                                optimiser.shiftYChanged.connect(optimiser.startImageConversionWrapper);
-                                optimiser.inputImageChanged.connect(optimiser.startImageConversionWrapper);
+                        Label {
+                            id: label11
+                            text: qsTr("Timeout")
+                        }
+
+                        SpinBox {
+                            id: timeOutSpinBox
+                            to: 999
+                            value: 30
+                            width: 140
+                            height: 32
+                            clip: false
+                            scale: 1
+                            wheelEnabled: true
+                            editable: true
+                            onValueChanged: optimiser.timeOut = value
+                        }
+                    }
+                    RowLayout {
+
+                        Label {
+                            id: label12
+                            text: qsTr("Bank Size")
+                        }
+                        ComboBox {
+                            id: exportBankSizeComboBox
+                            x: 0
+                            width: 0
+                            Layout.fillWidth: true
+                            enabled: false
+                            model: ["Default", "1kb", "2kb", "4kb"]
+                            Layout.fillHeight: false
+                            Layout.preferredHeight: 40
+                            Layout.preferredWidth: 90
+                            onCurrentIndexChanged: {
+                                const lookup = {"Default": 0, "1kb": 0x400, "2kb": 0x800, "4kb": 0x1000};
+                                optimiser.exportBankSize = lookup[model[currentIndex]];
                             }
-                            else
-                            {
-                                // Re-enable manual conversion button
-                                convertImageButton.enabled = true
-                                // Disconnect signals to stop starting automatically
-                                spriteModeComboBox.currentValueChanged.disconnect(optimiser.startImageConversionWrapper);
-                                bgModeComboBox.currentValueChanged.disconnect(optimiser.startImageConversionWrapper);
-                                xShiftSpinBox.valueModified.disconnect(optimiser.startImageConversionWrapper);
-                                yShiftSpinBox.valueModified.disconnect(optimiser.startImageConversionWrapper);
-                                maxBackgroundPalettesSpinBox.valueModified.disconnect(optimiser.startImageConversionWrapper);
-                                maxSpritePalettesSpinBox.valueModified.disconnect(optimiser.startImageConversionWrapper);
-                                maxSpritesPerScanlineSpinBox.valueModified.disconnect(optimiser.startImageConversionWrapper);
-                                optimiser.shiftXChanged.disconnect(optimiser.startImageConversionWrapper);
-                                optimiser.shiftYChanged.disconnect(optimiser.startImageConversionWrapper);
-                                optimiser.inputImageChanged.disconnect(optimiser.startImageConversionWrapper);
+                            Component.onCompleted: {
                             }
+                        }
+                    }
+                    RowLayout {
+                        Button {
+                            id: saveImageButton
+                            x: 0
+                            y: 88
+                            width: 206
+                            height: 32
+                            text: qsTr("Save converted PNG...")
+                            Component.onCompleted: {
+                                saveImageButton.onClicked.connect(saveConvertedDialog.openDialog);
+                            }
+                            enabled: false
+                        }
+                        Button {
+                            id: exportImageButton
+                            x: 0
+                            y: 124
+                            width: 206
+                            height: 32
+                            text: qsTr("Export...")
+                            Component.onCompleted: {
+                                exportImageButton.onClicked.connect(exportConvertedDialog.openDialog);
+                            }
+                            enabled: false
                         }
                     }
                 }


### PR DESCRIPTION
Used for mappers that aren't MMC5 but still support CHR banking, the new option will limit the number of BG tiles in a bank to the selected bank size. When exporting the row of tiles, if the number of new tiles on this row would cause a tile to spill into a new bank, then all of the tiles on that row will be put into a new bank in order to allow mappers to bank switch during HBlank.

![image](https://github.com/michel-iwaniec/OverlayPal/assets/952515/caef8ba7-bdd5-446f-a676-b81e04714665)
